### PR TITLE
[FEATURE] Make translate buttons configurable

### DIFF
--- a/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
+++ b/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Xclass;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2020 Ricky Mathew <ricky@web-vision.de>, web-vision GmbH
+ *      Anu Bhuvanendran Nair <anu@web-vision.de>, web-vision GmbH
+ *
+ *  You may not remove or change the name of the author above. See:
+ *  http://www.gnu.org/licenses/gpl-faq.html#IWantCredit
+ *
+ *  This script is part of the Typo3 project. The Typo3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\View\PageLayoutView;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PageLayoutViewConfigureLanguageButton extends PageLayoutView
+{
+    /**
+     * Creates button which is used to create copies of records..
+     *
+     * @param array $defaultLanguageUids Numeric array with uids of tt_content elements in the default language
+     * @param int $lP Sys language UID
+     * @return string "Copy languages" button, if available.
+     */
+    public function newLanguageButton($defaultLanguageUids, $lP)
+    {
+        $lP = (int)$lP;
+        if (!$this->doEdit || !$lP || !$this->hasContentModificationAndAccessPermissions()) {
+            return '';
+        }
+        $theNewButton = '';
+
+        $localizationTsConfig = BackendUtility::getPagesTSconfig($this->id)['mod.']['web_layout.']['localization.'] ?? [];
+        $allowCopy = (bool)($localizationTsConfig['enableCopy'] ?? true);
+        $allowTranslate = (bool)($localizationTsConfig['enableTranslate'] ?? true);
+
+        $allowDeeplTranslate = (bool)($localizationTsConfig['enableDeeplTranslate'] ?? true);
+        $allowDeeplTranslateAuto = (bool)($localizationTsConfig['enableDeeplTranslateAuto'] ?? true);
+        $allowGoogleTranslate = (bool)($localizationTsConfig['enableGoogleTranslate'] ?? true);
+        $allowGoogleTranslateAuto = (bool)($localizationTsConfig['enableGoogleTranslateAuto'] ?? true);
+
+        if (!empty($this->languageHasTranslationsCache[$lP])) {
+            if (isset($this->languageHasTranslationsCache[$lP]['hasStandAloneContent'])) {
+                $allowTranslate = false;
+            }
+            if (isset($this->languageHasTranslationsCache[$lP]['hasTranslations'])) {
+                $allowCopy = $allowCopy && !$this->languageHasTranslationsCache[$lP]['hasTranslations'];
+            }
+        }
+
+        if (isset($this->contentElementCache[$lP]) && is_array($this->contentElementCache[$lP])) {
+            foreach ($this->contentElementCache[$lP] as $column => $records) {
+                foreach ($records as $record) {
+                    $key = array_search($record['l10n_source'], $defaultLanguageUids);
+                    if ($key !== false) {
+                        unset($defaultLanguageUids[$key]);
+                    }
+                }
+            }
+        }
+
+        if (!empty($defaultLanguageUids)) {
+            $theNewButton =
+                '<a'
+                . ' href="#"'
+                . ' class="btn btn-default btn-sm t3js-localize disabled"'
+                . ' title="' . htmlspecialchars($this->getLanguageService()->getLL('newPageContent_translate')) . '"'
+                . ' data-page="' . htmlspecialchars($this->getLocalizedPageTitle()) . '"'
+                . ' data-has-elements="' . (int)!empty($this->contentElementCache[$lP]) . '"'
+                . ' data-allow-copy="' . (int)$allowCopy . '"'
+                . ' data-allow-translate="' . (int)$allowTranslate . '"'
+
+                . ' data-allow-deepl-translate="' . (int)$allowDeeplTranslate . '"'
+                . ' data-allow-deepl-translate-auto="' . (int)$allowDeeplTranslateAuto . '"'
+                . ' data-allow-ggogle-translate="' . (int)$allowGoogleTranslate . '"'
+                . ' data-allow-google-translate-auto="' . (int)$allowGoogleTranslateAuto . '"'
+
+                . ' data-table="tt_content"'
+                . ' data-page-id="' . (int)GeneralUtility::_GP('id') . '"'
+                . ' data-language-id="' . $lP . '"'
+                . ' data-language-name="' . htmlspecialchars($this->tt_contentConfig['languageCols'][$lP]) . '"'
+                . '>'
+                . $this->iconFactory->getIcon('actions-localize', Icon::SIZE_SMALL)->render()
+                . ' ' . htmlspecialchars($this->getLanguageService()->getLL('newPageContent_translate'))
+                . '</a>';
+        }
+
+        return $theNewButton;
+    }
+
+}

--- a/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
+++ b/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
@@ -38,6 +38,12 @@ use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * XCLASS core PageLayoutView
+ *
+ * @deprecated this is not longer required if feature toggle fluidBasedPageModule
+ *  is enabled. Can be removed in TYPO3 11.
+ */
 class PageLayoutViewConfigureLanguageButton extends PageLayoutView
 {
     /**

--- a/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
+++ b/Classes/Xclass/PageLayoutViewConfigureLanguageButton.php
@@ -103,7 +103,7 @@ class PageLayoutViewConfigureLanguageButton extends PageLayoutView
 
                 . ' data-allow-deepl-translate="' . (int)$allowDeeplTranslate . '"'
                 . ' data-allow-deepl-translate-auto="' . (int)$allowDeeplTranslateAuto . '"'
-                . ' data-allow-ggogle-translate="' . (int)$allowGoogleTranslate . '"'
+                . ' data-allow-google-translate="' . (int)$allowGoogleTranslate . '"'
                 . ' data-allow-google-translate-auto="' . (int)$allowGoogleTranslateAuto . '"'
 
                 . ' data-table="tt_content"'

--- a/Configuration/TsConfig/Page/pagetsconfig.txt
+++ b/Configuration/TsConfig/Page/pagetsconfig.txt
@@ -1,3 +1,8 @@
 TCEMAIN {
 translateToMessage =
 }
+
+mod.web_layout.localization.enableDeeplTranslate = 1
+mod.web_layout.localization.enableDeeplTranslateAuto = 1
+mod.web_layout.localization.enableGoogleTranslate = 1
+mod.web_layout.localization.enableGoogleTranslateAuto = 1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,28 @@ Once installed ,there appears a Deepl back end module with a settings tab.
 
 ## Extension Configuartion
 
-Once you installed the extension, you have to set the Deepl API Key under extension configuration section
+Once you installed the extension, you have to set the Deepl API Key under extension configuration section.
+
+The buttons in the translate dialog can be configured via Page TSconfig, for example:
+
+```
+mod.web_layout.localization.enableDeeplTranslate = 1
+mod.web_layout.localization.enableDeeplTranslateAuto = 0
+mod.web_layout.localization.enableGoogleTranslate = 0
+mod.web_layout.localization.enableGoogleTranslateAuto = 0
+```
+
+The already existing TYPO3 enableTranslate option must be active:
+
+```
+mod.web_layout.localization.enableTranslate = 1
+```
+
+The settings can be changed using User TSconfig (like all other Page TSconfig options):
+
+```
+page.mod.web_layout.localization.enableDeeplTranslate = 1
+```
 
 
 ## Translating content elements

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Once you installed the extension, you have to set the Deepl API Key under extens
 
 The buttons in the translate dialog can be configured via Page TSconfig, for example:
 
+**IMPORTANT:** This currently only works if the feature toggle *fluidBasedPageModule* is not activated.
+
 ```
 mod.web_layout.localization.enableDeeplTranslate = 1
 mod.web_layout.localization.enableDeeplTranslateAuto = 0

--- a/Resources/Public/JavaScript/Localization.js
+++ b/Resources/Public/JavaScript/Localization.js
@@ -144,46 +144,54 @@ Localization.initialize = function() {
     if ($triggerButton.data('allowTranslate')) {
         actions.push(
             '<div class="row">'
-                + '<div class="btn-group col-sm-3">' + Localization.actions.translate[0].outerHTML + '</div>'
-                + '<div class="col-sm-9">'
-                    + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.translate'] + '</p>'
-                + '</div>'
+            + '<div class="btn-group col-sm-3">' + Localization.actions.translate[0].outerHTML + '</div>'
+            + '<div class="col-sm-9">'
+            + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.translate'] + '</p>'
+            + '</div>'
             + '</div>'
         );
-        actions.push(
-            '<div class="row" id="deeplTranslateAuto">'
+
+        if ($triggerButton.data('allowDeeplTranslateAuto')) {
+            actions.push(
+                '<div class="row" id="deeplTranslateAuto">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.deepltranslateAuto[0].outerHTML + '</div>'
                 + '<div class="col-sm-9" id="deeplTextAuto">'
-                    + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.deepltranslateAuto']+ '</p>'
+                + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.deepltranslateAuto'] + '</p>'
                 + '</div>'
-            + '</div>'
-        );
-        actions.push(
-            '<div class="row" id="deeplTranslate">'
+                + '</div>'
+            );
+        }
+        if ($triggerButton.data('allowDeeplTranslate')) {
+            actions.push(
+                '<div class="row" id="deeplTranslate">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.deepltranslate[0].outerHTML + '</div>'
                 + '<div class="col-sm-9" id="deeplText">'
-                    + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.deepltranslate'] + '</p>'
+                + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.deepltranslate'] + '</p>'
                 + '</div>'
-            + '</div>'
-        );
-        actions.push(
-            '<div class="row" id="googleTranslate">'
+                + '</div>'
+            );
+        }
+        if ($triggerButton.data('allowGoogleTranslateAuto')) {
+            actions.push(
+                '<div class="row" id="googleTranslate">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslate[0].outerHTML + '</div>'
                 + '<div class="col-sm-9" id="googleText">'
-                    + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.googleTranslate'] + '</p>'
+                + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.googleTranslate'] + '</p>'
                 + '</div>'
-            + '</div>'
-        );
-        actions.push(
-            '<div class="row" id="googleTranslateAuto">'
+                + '</div>'
+            );
+        }
+        if ($triggerButton.data('allowGoogleTranslate')) {
+            actions.push(
+                '<div class="row" id="googleTranslateAuto">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslateAuto[0].outerHTML + '</div>'
                 + '<div class="col-sm-9" id="googleTextAuto">'
-                    + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.googleTranslateAuto'] + '</p>'
+                + '<p class="t3js-helptext t3js-helptext-translate text-muted">' + TYPO3.lang['localize.educate.googleTranslateAuto'] + '</p>'
                 + '</div>'
-            + '</div>'
-        );
+                + '</div>'
+            );
+        }
     }
-
     if ($triggerButton.data('allowCopy')) {
         actions.push(
             '<div class="row">'

--- a/Resources/Public/JavaScript/Localization.js
+++ b/Resources/Public/JavaScript/Localization.js
@@ -151,7 +151,11 @@ Localization.initialize = function() {
             + '</div>'
         );
 
-        if ($triggerButton.data('allowDeeplTranslateAuto')) {
+        // if allowDeeplTranslateAuto (and others) is undefined, we use default of "on"
+        // (could happen if fluidBasedPageModule feature toggle is on and LanguageColumns.html partial in this extension
+        // is not used)
+        var allowDeeplTranslateAuto = $triggerButton.data('allowDeeplTranslateAuto');
+        if (allowDeeplTranslateAuto == null || allowDeeplTranslateAuto) {
             actions.push(
                 '<div class="row" id="deeplTranslateAuto">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.deepltranslateAuto[0].outerHTML + '</div>'
@@ -161,7 +165,8 @@ Localization.initialize = function() {
                 + '</div>'
             );
         }
-        if ($triggerButton.data('allowDeeplTranslate')) {
+        var allowDeeplTranslate = $triggerButton.data('allowDeeplTranslate');
+        if (allowDeeplTranslate == null || allowDeeplTranslate) {
             actions.push(
                 '<div class="row" id="deeplTranslate">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.deepltranslate[0].outerHTML + '</div>'
@@ -171,7 +176,8 @@ Localization.initialize = function() {
                 + '</div>'
             );
         }
-        if ($triggerButton.data('allowGoogleTranslateAuto')) {
+        var allowGoogleTranslateAuto = $triggerButton.data('allowGoogleTranslateAuto');
+        if (allowGoogleTranslateAuto == null || allowGoogleTranslateAuto) {
             actions.push(
                 '<div class="row" id="googleTranslate">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslate[0].outerHTML + '</div>'
@@ -181,7 +187,8 @@ Localization.initialize = function() {
                 + '</div>'
             );
         }
-        if ($triggerButton.data('allowGoogleTranslate')) {
+        var allowGoogleTranslate = $triggerButton.data('allowGoogleTranslate');
+        if (allowGoogleTranslate == null || allowGoogleTranslate) {
             actions.push(
                 '<div class="row" id="googleTranslateAuto">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslateAuto[0].outerHTML + '</div>'

--- a/Resources/Public/JavaScript/Localization.js
+++ b/Resources/Public/JavaScript/Localization.js
@@ -176,8 +176,8 @@ Localization.initialize = function() {
                 + '</div>'
             );
         }
-        var allowGoogleTranslateAuto = $triggerButton.data('allowGoogleTranslateAuto');
-        if (allowGoogleTranslateAuto == null || allowGoogleTranslateAuto) {
+        var allowGoogleTranslate = $triggerButton.data('allowGoogleTranslate');
+        if (allowGoogleTranslate == null || allowGoogleTranslate) {
             actions.push(
                 '<div class="row" id="googleTranslate">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslate[0].outerHTML + '</div>'
@@ -187,8 +187,8 @@ Localization.initialize = function() {
                 + '</div>'
             );
         }
-        var allowGoogleTranslate = $triggerButton.data('allowGoogleTranslate');
-        if (allowGoogleTranslate == null || allowGoogleTranslate) {
+        var allowGoogleTranslateAuto = $triggerButton.data('allowGoogleTranslateAuto');
+        if (allowGoogleTranslateAuto == null || allowGoogleTranslateAuto) {
             actions.push(
                 '<div class="row" id="googleTranslateAuto">'
                 + '<div class="btn-group col-sm-3">' + Localization.actions.googletranslateAuto[0].outerHTML + '</div>'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,6 +23,9 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Recordlist\\RecordLis
 
 
 //xclass PageLayoutView to make DeepL + Google translate buttons configurable
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\View\PageLayoutView::class] = [
-    'className' =>  WebVision\WvDeepltranslate\Xclass\PageLayoutViewConfigureLanguageButton::class,
-];
+// only enable if feature toggle fluidBasedPageModule is not enabled
+if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('fluidBasedPageModule') == false) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\View\PageLayoutView::class] = [
+        'className' => WebVision\WvDeepltranslate\Xclass\PageLayoutViewConfigureLanguageButton::class,
+    ];
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,3 +20,9 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Backend\\Controller\\
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Recordlist\\RecordList\\DatabaseRecordList'] = array(
     'className' => 'WebVision\\WvDeepltranslate\\Override\\DatabaseRecordList',
 );
+
+
+//xclass PageLayoutView to make DeepL + Google translate buttons configurable
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\View\PageLayoutView::class] = [
+    'className' =>  WebVision\WvDeepltranslate\Xclass\PageLayoutViewConfigureLanguageButton::class,
+];


### PR DESCRIPTION
still draft, todos:

* [ ] Must test with feature toggle fluidBasedPageModule enabled as well.
* [ ] conventions for setting TSconfig by extensions? Should `mod.web_layout.localization.` be used by third party extensions (there may be namespace conflicts) ... use extension configuration instead?

It is now possible to make the available translate buttons configurable
via Page TSconfig.

TYPO3 already uses these settings for the translate and config button:

```
mod.web_layout.localization.enableCopy = 1
mod.web_layout.localization.enableTranslate = 1

```
This is now extended with configuration for deepl / google translate:

```
mod.web_layout.localization.enableDeeplTranslate = 1
mod.web_layout.localization.enableDeeplTranslateAuto = 1
mod.web_layout.localization.enableGoogleTranslate = 1
mod.web_layout.localization.enableGoogleTranslateAuto = 1
```

All buttons are active by default, which matches the behaviour before
this change.

Resolves: #8