### PR TITLE
Add php doc blocks

### DIFF
--- a/Classes/Domain/Model/Settings.php
+++ b/Classes/Domain/Model/Settings.php
@@ -6,8 +6,14 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class Settings extends AbstractEntity
 {
+    /**
+     * @var string
+     */
     protected string $languagesAssigned = '';
 
+    /**
+     * @var int
+     */
     protected int $createDate = 0;
 
     public function getLanguagesAssigned(): array


### PR DESCRIPTION
Closes: #93

Needed as long there is support for TYPO3 v9 LTS. With v10 the doc blocks are not needed anymore.