### PR TITLE
[BUGFIX] Fix glossary sync persistance

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -148,10 +148,10 @@ class DataHandlerHook implements LoggerAwareInterface
 
                 $entries = $this->glossariesRepository->processGlossariesEntries($langUid);
                 $glossaryName = $glossaryNamePrefix . '-' . strtoupper($sourceLang) . '-' . strtoupper($targetLang);
-            }
 
-            if (!empty($entries)) {
-                $this->prepareGlossarEntries($glossaryName, $entries, $sourceLang, $targetLang);
+                if (!empty($entries)) {
+                    $this->prepareGlossarEntries($glossaryName, $entries, $sourceLang, $targetLang);
+                }
             }
         } else {
             $systemLanguages = $this->languageRepository->findAll();


### PR DESCRIPTION
Due to a bug in the DataHandlerHook, the glossary entries were not synchronized to the table tx_wvdeepltranslate_domain_model_glossariessync.

This typically occurred in sites with several languages because a for loop was exited too early.

Due to the glossary entries not being synchronized, the glossary was not used for translation.

Resolves: #99