### PR TITLE
[BUGFIX] Fix undefined array key in DataHandlerHook

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -95,7 +95,8 @@ class DataHandlerHook implements LoggerAwareInterface
         if ($status !== 'update') {
             return;
         }
-        if ($fieldArray['l10n_parent'] === 0) {
+
+        if (!isset($fieldArray['l10n_parent']) || $fieldArray['l10n_parent'] === 0) {
             return;
         }
 


### PR DESCRIPTION
Problem occurs with PHP 8.1.

Resolves: #98