### PR TITLE
[FEATURE] add supported languages automatically from API

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,3 +20,12 @@ services:
 
   WebVision\WvDeepltranslate\Hooks\DataHandlerHook:
     public: true
+
+  WebVision\WvDeepltranslate\Service\DeeplService:
+    arguments:
+      $cache: '@cache.wvdeepltranslate'
+
+  cache.wvdeepltranslate:
+    class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
+    factory: [ '@TYPO3\CMS\Core\Cache\CacheManager', 'getCache' ]
+    arguments: [ 'wvdeepltranslate' ]

--- a/Tests/Functional/Fixtures/ExtensionConfig.php
+++ b/Tests/Functional/Fixtures/ExtensionConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+getenv('DEEPL_API_KEY') or die('Environment variable DEEPL_API_KEY is not set. Please set in local Context in ddev config.yaml');
+
+return [
+    'EXTENSIONS' => [
+        'wv_deepltranslate' => [
+            'apiKey' => getenv('DEEPL_API_KEY') ?? '',
+            'apiUrl' => 'https://api-free.deepl.com/v2/translate',
+            'deeplFormality' => 'default',
+            'googleapiKey' => '',
+            'googleapiUrl' => 'https://translation.googleapis.com/language/translate/v2',
+        ],
+    ],
+];

--- a/Tests/Functional/Services/DeeplServiceTest.php
+++ b/Tests/Functional/Services/DeeplServiceTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace Functional\Services;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use WebVision\WvDeepltranslate\Service\DeeplService;
+
+class DeeplServiceTest extends FunctionalTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/wv_deepltranslate',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->configurationToUseInTestInstance = array_merge(
+            $this->configurationToUseInTestInstance,
+            require __DIR__ . '/../Fixtures/ExtensionConfig.php'
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importDataSet(__DIR__ . '/../Fixtures/Settings.xml');
+        $this->importDataSet(__DIR__ . '/../Fixtures/Language.xml');
+    }
+
+    /**
+     * @test
+     */
+    public function checkSupportedLanguages(): void
+    {
+        $deeplService = GeneralUtility::makeInstance(DeeplService::class);
+
+        static::assertContains('EN-GB', $deeplService->apiSupportedLanguages);
+        static::assertContains('EN-US', $deeplService->apiSupportedLanguages);
+        static::assertContains('DE', $deeplService->apiSupportedLanguages);
+        static::assertContains('UK', $deeplService->apiSupportedLanguages);
+    }
+
+    /**
+     * @test
+     */
+    public function checkFormalitySupportedLanguages(): void
+    {
+        $deeplService = GeneralUtility::makeInstance(DeeplService::class);
+
+        static::assertContains('ES', $deeplService->formalitySupportedLanguages);
+        static::assertContains('DE', $deeplService->formalitySupportedLanguages);
+        static::assertContains('NL', $deeplService->formalitySupportedLanguages);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -69,4 +69,10 @@ if (!defined('TYPO3_MODE')) {
             );
         }
     }
+
+    //add caching for DeepL API supported Languages
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['wvdeepltranslate']
+        ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['wvdeepltranslate']['backend']
+        ??= \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
 })();


### PR DESCRIPTION
Fixes #63.

This PR will add support to automatically check for available DeepL supported languages. For not running into API restrictions a caching is added.