### PR TITLE
[TASK] add news extension as dev-require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
 		"armin/editorconfig-cli": "^1.5",
 		"b13/container": "^1.6",
 		"friendsofphp/php-cs-fixer": "^3.0",
+		"georgringer/news": "^10.0",
 		"helhum/typo3-console": "^5.8 || ^6.7 || ^7.1",
 		"helmich/typo3-typoscript-lint": "^2.5",
 		"phpstan/phpstan": "^1.3",


### PR DESCRIPTION
tx_news comes with allowLanguageSynchronisation behavior for some fields. According to this, this ext should be used as dev requirement for testing the l10n_state and the behaviour with state modes.