### PR TITLE
Fix language translate button and select

### DIFF
--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace WebVision\WvDeepltranslate\Override;
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Recordlist\Controller\RecordListController;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
@@ -32,12 +33,27 @@ class DeeplRecordListController extends RecordListController
         if ($options == '') {
             return '';
         }
-        return str_replace('<div class="col-auto">', '<div class="col-auto row"><div class="col-sm-6">', $originalOutput)
-            . '<div class="col-sm-6 row">'
-            . '<label class="col-sm-4">Translate with DeepL</label>'
-            . '<div class="col-sm-8">'
-            . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
-            . $options
-            . '</select></div></div></div>';
+
+        $deeplSelectLabel = LocalizationUtility::translate(
+            'backend.label',
+            'wv_deepltranslate'
+        );
+
+        return str_replace(
+            '<div class="col-auto">',
+            '<div class="col-auto row"><div class="col-sm-6">',
+            $originalOutput
+        )
+            . '<div class="col-sm-6">'
+                . '<div class="row">'
+                    . '<label class="col-sm-4" style="font-weight: bold;">' . $deeplSelectLabel . ':</label>'
+                    . '<div class="col-sm-8">'
+                        . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
+                            . $options
+                        . '</select>'
+                    . '</div>'
+                . '</div>'
+            . '</div>'
+            . '</div>';
     }
 }

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -9,7 +9,10 @@ use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
 class DeeplRecordListController extends RecordListController
 {
-    protected function languageSelector(string $requestUri): string
+    /**
+     * @param string $requestUri
+     */
+    protected function languageSelector($requestUri): string
     {
         $originalOutput = parent::languageSelector($requestUri);
 

--- a/Classes/Override/v10/DatabaseRecordList.php
+++ b/Classes/Override/v10/DatabaseRecordList.php
@@ -60,7 +60,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                         && $this->getBackendUserAuthentication()->checkLanguageAccess($lUid_OnPage)
                     ) {
                         $language = BackendUtility::getRecord('sys_language', $lUid_OnPage, 'title');
-                        $lNew = DeeplBackendUtility::buildTranslateButton(
+                        $lNew .= DeeplBackendUtility::buildTranslateButton(
                             $table,
                             $row['uid'],
                             $lUid_OnPage,

--- a/Classes/Override/v10/DeeplPageLayoutView.php
+++ b/Classes/Override/v10/DeeplPageLayoutView.php
@@ -34,7 +34,6 @@ class DeeplPageLayoutView extends PageLayoutView
             return '';
         }
 
-        //return $originalOutput;
         $originalOutput = str_ireplace('</div></div>', '</div>', $originalOutput);
         return $originalOutput
             . '<div class="form-group">'

--- a/Classes/Override/v10/DeeplRecordListController.php
+++ b/Classes/Override/v10/DeeplRecordListController.php
@@ -11,6 +11,8 @@ use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
 /**
  * @deprecated will be removed in version 4
+ *
+ * use in TYPO3 Version 9 and 10 when Feature Toggle disabled
  */
 class DeeplRecordListController extends RecordListController
 {

--- a/Classes/Override/v10/DeeplRecordListController.php
+++ b/Classes/Override/v10/DeeplRecordListController.php
@@ -14,6 +14,9 @@ use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
  */
 class DeeplRecordListController extends RecordListController
 {
+    /**
+     * @param int $id
+     */
     protected function languageSelector($id): string
     {
         $originalOutput = parent::languageSelector($id);

--- a/Classes/Override/v10/DeeplRecordListController.php
+++ b/Classes/Override/v10/DeeplRecordListController.php
@@ -22,7 +22,6 @@ class DeeplRecordListController extends RecordListController
     protected function languageSelector($id): string
     {
         $originalOutput = parent::languageSelector($id);
-
         if ($originalOutput == '') {
             return $originalOutput;
         }
@@ -34,20 +33,24 @@ class DeeplRecordListController extends RecordListController
             $this->id,
             GeneralUtility::getIndpEnv('REQUEST_URI')
         );
+
         if ($options == '') {
             return '';
         }
+
         return str_ireplace('</div></div>', '</div>', $originalOutput)
             . '<div class="form-group">'
-            . sprintf(
-                '<label>%s</label>',
-                LocalizationUtility::translate(
-                    'backend.label',
-                    'wv_deepltranslate'
+                . sprintf(
+                    '<label>%s</label>',
+                    LocalizationUtility::translate(
+                        'backend.label',
+                        'wv_deepltranslate'
+                    )
                 )
-            )
-            . '<select class="form-control input-sm" name="createNewLanguage" onchange="window.location.href=this.options[this.selectedIndex].value">'
-            . $options
-            . '</select></div></div></div>';
+                . '<select class="form-control input-sm" name="createNewLanguage" onchange="window.location.href=this.options[this.selectedIndex].value">'
+                    . $options
+                . '</select>'
+            . '</div>'
+            . '</div>';
     }
 }

--- a/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
@@ -1,8 +1,12 @@
 <html
-lang="en"
-xmlns:deepl="http://typo3.org/ns/WebVision/WvDeepltranslate/ViewHelpers"
-xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
+    lang="en"
+    xmlns:deepl="http://typo3.org/ns/WebVision/WvDeepltranslate/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
 >
+<f:comment>
+    Use in TYPO3 v11 default
+</f:comment>
+
 <f:if condition="{context.newLanguageOptions}">
     <div class="row row-cols-auto align-items-end g-3 mb-3">
         <div class="col">

--- a/Resources/Private/Backend/Partials/v10/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/v10/PageLayout/LanguageColumns.html
@@ -1,0 +1,149 @@
+<html
+    lang="en"
+    xmlns:deepl="http://typo3.org/ns/WebVision/WvDeepltranslate/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
+>
+<f:comment>
+    Use in TYPO3 v10 when feature toggle enabled
+</f:comment>
+<f:if condition="{context.newLanguageOptions}">
+    <div class="form-inline form-inline-spaced">
+        <div class="form-group">
+            <select class="form-control input-sm" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                <f:for each="{context.newLanguageOptions}" as="languageName" key="url">
+                    <option value="{url}">{languageName}</option>
+                </f:for>
+            </select>
+        </div>
+        <div class="form-group">
+            <label >{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
+            <select class="form-control input-sm" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                <deepl:deeplTranslate context="{context}"/>
+                <f:for each="{deepl:deeplTranslate(context: '{context}')}" as="languageName" key="url">
+                    <option value="{url}">{languageName}</option>
+                </f:for>
+            </select>
+        </div>
+    </div>
+</f:if>
+<f:comment><!-- Identical to backend/Resources/Partials/PageLayout/LanguageColumns only copied --></f:comment>
+<div class="t3-grid-container">
+    <table cellpadding="0" cellspacing="0" class="t3-page-columns t3-grid-table t3js-page-columns">
+        <tr>
+            <f:for each="{languageColumns}" as="languageColumn">
+                <td valign="top"
+                    class="t3-page-column t3-page-column-lang-name"
+                    data-language-uid="{languageColumn.context.siteLanguage.languageId}"
+                    data-language-title="{languageColumn.context.siteLanguage.title}"
+                    data-flag-identifier="{languageColumn.context.siteLanguage.flagIdentifier}"
+                >
+                    <h2>{languageColumn.context.siteLanguage.title}</h2>
+                    <f:if condition="{languageColumn.context.languageMode}">
+                        <span class="label label-{languageColumn.context.languageModeLabelClass}">{languageColumn.context.languageMode}</span>
+                    </f:if>
+                </td>
+            </f:for>
+        </tr>
+        <tr>
+            <f:for each="{languageColumns}" as="languageColumn">
+                <td class="t3-page-column t3-page-lang-label nowrap">
+                    <div class="btn-group">
+                        <f:if condition="{languageColumn.allowViewPage}">
+                            <a href="#" class="btn btn-default btn-sm" onclick="{languageColumn.viewPageOnClick}" title="{languageColumn.viewPageLinkTitle}">
+                                <core:icon identifier="actions-view" />
+                            </a>
+                        </f:if>
+                        <f:if condition="{languageColumn.allowEditPage}">
+                            <a href="{languageColumn.pageEditUrl}" class="btn btn-default btn-sm" title="{languageColumn.pageEditTitle}">
+                                <core:icon identifier="actions-open" />
+                            </a>
+                        </f:if>
+                        <f:if condition="{allowEditContent} && {languageColumn.context.siteLanguage.languageId} && {languageColumn.translationData.untranslatedRecordUids}">
+                            <a href="#" class="btn btn-default btn-sm t3js-localize disabled"
+                               title="{languageColumn.context.translatePageTitle}"
+                               data-page="{languageColumn.context.localizedPageRecord.title}"
+                               data-has-elements="{languageColumn.translationData.hasTranslations as integer}"
+                               data-allow-copy="{languageColumn.allowTranslateCopy as integer}"
+                               data-allow-translate="{languageColumn.allowTranslate as integer}"
+                               data-table="tt_content"
+                               data-page-id="{context.pageId}"
+                               data-language-id="{languageColumn.context.siteLanguage.languageId}"
+                               data-language-name="{languageColumn.context.siteLanguage.title}">
+                                <core:icon identifier="actions-localize" />
+                                {languageColumn.translatePageTitle}
+                            </a>
+                        </f:if>
+                    </div>
+                    {languageColumn.pageIcon -> f:format.raw()}
+                    {languageColumn.context.localizedPageTitle}
+                </td>
+            </f:for>
+        </tr>
+        <f:if condition="{context.drawingConfiguration.defaultLanguageBinding}">
+            <f:then>
+                <f:variable name="grid" value="{languageColumns.0.grid}" />
+                <f:for each="{context.drawingConfiguration.activeColumns}" as="columnNumber">
+                    <tr>
+                        <f:for each="{languageColumns}" as="languageColumn">
+                            <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                            <td data-colpos="{column.columnNumber}" valign="top">
+                                <f:render partial="PageLayout/Grid/ColumnHeader" arguments="{_all}" />
+                            </td>
+                        </f:for>
+                    </tr>
+                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumns.0, columnNumber: columnNumber)}" />
+                    <f:for each="{column.items}" as="gridItem" iteration="itemIterator">
+                        <tr>
+                            <td class="t3-grid-cell" valign="top" data-colpos="{column.columnNumber}">
+                                <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumns.0, columnNumber: columnNumber)}" />
+                                <f:variable name="item" value="{gridItem}" />
+                                <f:render partial="PageLayout/Record" arguments="{_all}" />
+                            </td>
+                            <f:for each="{languageColumns}" as="languageColumn">
+                                <f:if condition="{languageColumn.context.siteLanguage.languageId} > 0">
+                                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                                    <td class="t3-grid-cell" valign="top" data-colpos="{column.columnNumber}">
+                                        <f:variable name="languageId" value="{languageColumn.context.siteLanguage.languageId}" />
+                                        <f:if condition="{languageColumn.translationData.mode} == 'connected'">
+                                            <f:then>
+                                                <f:if condition="{gridItem.translations.{languageId}}">
+                                                    <f:variable name="item" value="{gridItem.translations.{languageId}}" />
+                                                    <f:render partial="PageLayout/Record" arguments="{_all}" />
+                                                </f:if>
+                                            </f:then>
+                                            <f:else>
+                                                <f:if condition="{itemIterator.isFirst}">
+                                                    <f:variable name="languageColumnNonConnected">{languageColumns.{languageId}}</f:variable>
+                                                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumnNonConnected, columnNumber: columnNumber)}" />
+                                                    <f:for each="{column.items}" as="item">
+                                                        <f:render partial="PageLayout/Record" arguments="{_all}" />
+                                                    </f:for>
+                                                </f:if>
+                                            </f:else>
+                                        </f:if>
+                                    </td>
+                                </f:if>
+                            </f:for>
+                        </tr>
+                    </f:for>
+                </f:for>
+            </f:then>
+            <f:else>
+                <f:for each="{context.drawingConfiguration.activeColumns}" as="columnNumber">
+                    <tr>
+                        <f:for each="{languageColumns}" as="languageColumn">
+                            <f:if condition="{languageColumn.grid.columns}">
+                                <f:variable name="grid" value="{languageColumn.grid}" />
+                                <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                                <f:render partial="PageLayout/Grid/Column" arguments="{_all}" />
+                            </f:if>
+                        </f:for>
+                    </tr>
+                </f:for>
+            </f:else>
+        </f:if>
+    </table>
+</div>
+
+
+</html>

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -23,3 +23,7 @@ module.tx_backend.view {
         10 = EXT:wv_deepltranslate/Resources/Private/Backend/Partials
     }
 }
+
+[compatVersion("10.4")]
+    module.tx_backend.view.partialRootPaths.10 = EXT:wv_deepltranslate/Resources/Private/Backend/Partials/v10
+[END]


### PR DESCRIPTION

- PHP error had to be fixed in an override class.
- The new translation button was only render with the last language version, this is now fixed. There should now be a DeepL translation button in Record Listener for all languages.
- In addition, the language translation selects in Records List and Pages View modules were incorrect in different versions and had to be adjusted.