### PR TITLE
 Fix DeepL Translation for fields with behaviour->allowLanguageSynchronization

### DIFF
--- a/Classes/Hooks/AllowLanguageSynchronizationHook.php
+++ b/Classes/Hooks/AllowLanguageSynchronizationHook.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Hooks;
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+class AllowLanguageSynchronizationHook
+{
+    public function processDatamap_beforeStart(DataHandler $dataHandler): void
+    {
+        foreach ($dataHandler->datamap as $table => $elements) {
+            foreach ($elements as $key => $element) {
+                // element already exists, ignore
+                if (MathUtility::canBeInterpretedAsInteger($key)) {
+                    continue;
+                }
+                $l10nState = [];
+                foreach ($element as $column => $value) {
+                    $columnConfig = $GLOBALS['TCA'][$table]['columns'][$column];
+                    if (
+                        is_array($columnConfig['config']['behaviour'])
+                        && array_key_exists('allowLanguageSynchronization', $columnConfig['config']['behaviour'])
+                        && $columnConfig['config']['behaviour']['allowLanguageSynchronization']
+                    ) {
+                        if ($columnConfig['l10n_mode'] == 'prefixLangTitle') {
+                            $l10nState[$column] = 'custom';
+                        } else {
+                            $l10nState[$column] = 'parent';
+                        }
+                    }
+                }
+                if (!empty($l10nState)) {
+                    $element['l10n_state'] = json_encode($l10nState);
+                    $dataHandler->datamap[$table][$key] = $element;
+                }
+            }
+        }
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,6 +8,10 @@ if (!defined('TYPO3_MODE')) {
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:wv_deepltranslate/Configuration/TsConfig/Page/pagetsconfig.tsconfig">'
     );
 
+    //allowLanguageSynchronizationHook manipulates l10n_state
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
+        = \WebVision\WvDeepltranslate\Hooks\AllowLanguageSynchronizationHook::class;
+
     //hook for translate content
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processTranslateToClass']['deepl']
         = \WebVision\WvDeepltranslate\Hooks\TranslateHook::class;
@@ -20,7 +24,7 @@ if (!defined('TYPO3_MODE')) {
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processTranslateToClass'][] = \WebVision\WvDeepltranslate\Hooks\DataHandlerHook::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \WebVision\WvDeepltranslate\Hooks\DataHandlerHook::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] =  \WebVision\WvDeepltranslate\Hooks\DataHandlerHook::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \WebVision\WvDeepltranslate\Hooks\DataHandlerHook::class;
     //xclass localizationcontroller for localizeRecords() and process() action
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\Controller\Page\LocalizationController::class] = [
         'className' => \WebVision\WvDeepltranslate\Override\LocalizationController::class,


### PR DESCRIPTION
Separate Bugfix from #140 

Add DeepL Translation for fields with "behaviour->allowLanguageSynchronization" enabled, sets synchronization to custom

Fixes #87 
Fixes #115