### PR TITLE
[BUGFIX] Hide DeepL controls for not supported languages

### DIFF
--- a/Classes/Hooks/AllowLanguageSynchronizationHook.php
+++ b/Classes/Hooks/AllowLanguageSynchronizationHook.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace WebVision\WvDeepltranslate\Hooks;
 

--- a/Classes/Override/DatabaseRecordList.php
+++ b/Classes/Override/DatabaseRecordList.php
@@ -52,6 +52,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                     && !$this->isRecordDeletePlaceholder($row)
                     && !isset($translations[$lUid_OnPage])
                     && $this->getBackendUserAuthentication()->checkLanguageAccess($lUid_OnPage)
+                    && DeeplBackendUtility::checkCanBeTranslated($pageId, $lUid_OnPage)
                 ) {
                     $out .= DeeplBackendUtility::buildTranslateButton(
                         $table,

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -45,14 +45,9 @@ class DeeplRecordListController extends RecordListController
             $originalOutput
         )
             . '<div class="col-sm-6">'
-                . '<div class="row">'
-                    . '<label class="col-sm-4" style="font-weight: bold;">' . $deeplSelectLabel . ':</label>'
-                    . '<div class="col-sm-8">'
-                        . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
-                            . $options
-                        . '</select>'
-                    . '</div>'
-                . '</div>'
+            . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
+            . $options
+            . '</select>'
             . '</div>'
             . '</div>';
     }

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -30,8 +30,9 @@ class DeeplRecordListController extends RecordListController
             $this->id,
             $requestUri
         );
+
         if ($options == '') {
-            return '';
+            return $originalOutput;
         }
 
         return str_replace(

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -34,11 +34,6 @@ class DeeplRecordListController extends RecordListController
             return '';
         }
 
-        $deeplSelectLabel = LocalizationUtility::translate(
-            'backend.label',
-            'wv_deepltranslate'
-        );
-
         return str_replace(
             '<div class="col-auto">',
             '<div class="col-auto row"><div class="col-sm-6">',

--- a/Classes/Override/v10/DatabaseRecordList.php
+++ b/Classes/Override/v10/DatabaseRecordList.php
@@ -58,6 +58,10 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                         && $this->isEditable($table)
                         && !isset($translations['translations'][$lUid_OnPage])
                         && $this->getBackendUserAuthentication()->checkLanguageAccess($lUid_OnPage)
+                        && DeeplBackendUtility::checkCanBeTranslated(
+                            ($table === 'pages') ? $row['uid'] : $row['pid'],
+                            $lUid_OnPage
+                        )
                     ) {
                         $language = BackendUtility::getRecord('sys_language', $lUid_OnPage, 'title');
                         $lNew .= DeeplBackendUtility::buildTranslateButton(

--- a/Classes/Override/v10/DeeplPageLayoutView.php
+++ b/Classes/Override/v10/DeeplPageLayoutView.php
@@ -37,13 +37,6 @@ class DeeplPageLayoutView extends PageLayoutView
         $originalOutput = str_ireplace('</div></div>', '</div>', $originalOutput);
         return $originalOutput
             . '<div class="form-group">'
-            . sprintf(
-                '<label>%s</label>',
-                LocalizationUtility::translate(
-                    'backend.label',
-                    'wv_deepltranslate'
-                )
-            )
             . '<select class="form-control input-sm" onchange="window.location.href=this.options[this.selectedIndex].value">'
             . $options
             . '</select></div></div>';

--- a/Classes/Override/v10/DeeplPageLayoutView.php
+++ b/Classes/Override/v10/DeeplPageLayoutView.php
@@ -30,8 +30,9 @@ class DeeplPageLayoutView extends PageLayoutView
             $this->id,
             GeneralUtility::getIndpEnv('REQUEST_URI')
         );
+
         if ($options == '') {
-            return '';
+            return $originalOutput;
         }
 
         $originalOutput = str_ireplace('</div></div>', '</div>', $originalOutput);

--- a/Classes/Override/v10/DeeplRecordListController.php
+++ b/Classes/Override/v10/DeeplRecordListController.php
@@ -35,7 +35,7 @@ class DeeplRecordListController extends RecordListController
         );
 
         if ($options == '') {
-            return '';
+            return $originalOutput;
         }
 
         return str_ireplace('</div></div>', '</div>', $originalOutput)

--- a/Classes/Override/v10/DeeplRecordListController.php
+++ b/Classes/Override/v10/DeeplRecordListController.php
@@ -40,13 +40,6 @@ class DeeplRecordListController extends RecordListController
 
         return str_ireplace('</div></div>', '</div>', $originalOutput)
             . '<div class="form-group">'
-                . sprintf(
-                    '<label>%s</label>',
-                    LocalizationUtility::translate(
-                        'backend.label',
-                        'wv_deepltranslate'
-                    )
-                )
                 . '<select class="form-control input-sm" name="createNewLanguage" onchange="window.location.href=this.options[this.selectedIndex].value">'
                     . $options
                 . '</select>'

--- a/Classes/ViewHelpers/DeeplTranslateViewHelper.php
+++ b/Classes/ViewHelpers/DeeplTranslateViewHelper.php
@@ -46,7 +46,6 @@ class DeeplTranslateViewHelper extends AbstractViewHelper
         }
         foreach ($context->getNewLanguageOptions() as $key => $possibleLanguage) {
             if ($key === 0) {
-                $options[] = LocalizationUtility::translate('backend.label', 'wv_deepltranslate');
                 continue;
             }
             if (!array_key_exists($possibleLanguage, $languageMatch)) {

--- a/Classes/ViewHelpers/DeeplTranslateViewHelper.php
+++ b/Classes/ViewHelpers/DeeplTranslateViewHelper.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace WebVision\WvDeepltranslate\ViewHelpers;
 
 use TYPO3\CMS\Backend\View\PageLayoutContext;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
@@ -33,13 +34,22 @@ class DeeplTranslateViewHelper extends AbstractViewHelper
                 $siteLanguage->getLanguageId() != -1
                 && $siteLanguage->getLanguageId() != 0
             ) {
+                if (!DeeplBackendUtility::checkCanBeTranslated($context->getPageId(), $siteLanguage->getLanguageId())) {
+                    continue;
+                }
                 $languageMatch[$siteLanguage->getTitle()] = $siteLanguage->getLanguageId();
             }
         }
 
+        if (count($languageMatch) === 0) {
+            return $options;
+        }
         foreach ($context->getNewLanguageOptions() as $key => $possibleLanguage) {
             if ($key === 0) {
-                $options[] = $possibleLanguage;
+                $options[] = LocalizationUtility::translate('backend.label', 'wv_deepltranslate');
+                continue;
+            }
+            if (!array_key_exists($possibleLanguage, $languageMatch)) {
                 continue;
             }
             $parameters = [

--- a/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
@@ -3,9 +3,9 @@
     xmlns:deepl="http://typo3.org/ns/WebVision/WvDeepltranslate/ViewHelpers"
     xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
 >
-<f:comment>
+<f:comment><!--
     Use in TYPO3 v11 default
-</f:comment>
+--></f:comment>
 
 <f:if condition="{context.newLanguageOptions}">
     <div class="row row-cols-auto align-items-end g-3 mb-3">
@@ -16,16 +16,20 @@
                 </f:for>
             </select>
         </div>
-        <div class="col row">
-            <label class="col-sm-4 col">{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
-            <div class="col col-sm-8">
-                <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
-                    <f:for each="{deepl:deeplTranslate(context: '{context}')}" as="languageName" key="url">
-                        <option value="{url}">{languageName}</option>
-                    </f:for>
-                </select>
-            </div>
-        </div>
+        <f:alias map="{deeplLanguages: '{deepl:deeplTranslate(context: \'{context}\')}'}">
+            <f:if condition="{deeplLanguages -> f:count()} > 0">
+                <div class="col row">
+                    <label class="col-sm-4 col">{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
+                    <div class="col col-sm-8">
+                        <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                            <f:for each="{deeplLanguages}" as="languageName" key="url">
+                                <option value="{url}">{languageName}</option>
+                            </f:for>
+                        </select>
+                    </div>
+                </div>
+            </f:if>
+        </f:alias>
     </div>
 </f:if>
 <f:comment><!-- Identical to backend/Resources/Partials/PageLayout/LanguageColumns only copied --></f:comment>

--- a/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
@@ -22,6 +22,7 @@
                     <label class="col-sm-4 col">{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
                     <div class="col col-sm-8">
                         <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                            <option><f:translate key="backend.label" extensionName="wv_deepltranslate" /></option>
                             <f:for each="{deeplLanguages}" as="languageName" key="url">
                                 <option value="{url}">{languageName}</option>
                             </f:for>

--- a/Resources/Private/Backend/v10/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/v10/Partials/PageLayout/LanguageColumns.html
@@ -20,6 +20,7 @@
                 <div class="form-group">
                     <label >{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
                     <select class="form-control input-sm" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                        <option><f:translate key="backend.label" extensionName="wv_deepltranslate" /></option>
                         <f:for each="{deeplLanguages}" as="languageName" key="url">
                             <option value="{url}">{languageName}</option>
                         </f:for>

--- a/Resources/Private/Backend/v10/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/v10/Partials/PageLayout/LanguageColumns.html
@@ -3,9 +3,9 @@
     xmlns:deepl="http://typo3.org/ns/WebVision/WvDeepltranslate/ViewHelpers"
     xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
 >
-<f:comment>
+<f:comment><!--
     Use in TYPO3 v10 when feature toggle enabled
-</f:comment>
+--></f:comment>
 <f:if condition="{context.newLanguageOptions}">
     <div class="form-inline form-inline-spaced">
         <div class="form-group">
@@ -15,14 +15,18 @@
                 </f:for>
             </select>
         </div>
-        <div class="form-group">
-            <label >{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
-            <select class="form-control input-sm" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
-                <f:for each="{deepl:deeplTranslate(context: '{context}')}" as="languageName" key="url">
-                    <option value="{url}">{languageName}</option>
-                </f:for>
-            </select>
-        </div>
+        <f:alias map="{deeplLanguages: '{deepl:deeplTranslate(context: \'{context}\')}'}">
+            <f:if condition="{deeplLanguages -> f:count()} > 0">
+                <div class="form-group">
+                    <label >{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
+                    <select class="form-control input-sm" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+                        <f:for each="{deeplLanguages}" as="languageName" key="url">
+                            <option value="{url}">{languageName}</option>
+                        </f:for>
+                    </select>
+                </div>
+            </f:if>
+        </f:alias>
     </div>
 </f:if>
 <f:comment><!-- Identical to backend/Resources/Partials/PageLayout/LanguageColumns only copied --></f:comment>

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -26,6 +26,6 @@ module.tx_backend.view {
     }
 }
 
-[compatVersion("10.4")]
-    module.tx_backend.view.partialRootPaths.10 = EXT:wv_deepltranslate/Resources/Private/Backend/Partials/v10
+[typo3.version < "11.5"]
+    module.tx_backend.view.partialRootPaths.10 = EXT:wv_deepltranslate/Resources/Private/Backend/v10/Partials
 [END]


### PR DESCRIPTION
All DeepL related localization elements are hidden, if target language is not supported by DeepL.

Does not appear to the Localization wizard. Fixes only translation buttons and translation dropdowns.

fixes #30