### PR TITLE
Add conflicts to recordlist_thumbnail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
 		"issues": "https://github.com/web-vision/wv_deepltranslate/issues",
 		"source": "https://github.com/web-vision/wv_deepltranslate"
 	},
+	"conflict": {
+		"studiomitte/recordlist-thumbnail": "*"
+	},
 	"config": {
 		"vendor-dir": ".Build/vendor",
 		"bin-dir": ".Build/bin",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,9 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '9.5.1-11.5.99',
         ],
-        'conflicts' => [],
+        'conflicts' => [
+            'recordlist_thumbnail' => '*'
+        ],
         'suggests' => [],
     ],
     'autoload' => [


### PR DESCRIPTION
fixes #151 

* Affected TYPO3 version: 11 and above
* installed ext: https://github.com/studiomitte/recordlist_thumbnail

This is because recordlist_thumbnail x-classes the DatabaseRecordList, as we do, too. 
https://github.com/studiomitte/recordlist_thumbnail/tree/main/Classes/Xclass

It would a big impact, overriding the Xlcass in this extension, because we can't consider side effects.

Solution: Add conflict to recordlist_thumbnail