### PR TITLE
[BUGFIX] Fix active old backend module condition type handling

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,4 +10,4 @@ googleapiKey =
 googleapiUrl = https://translation.googleapis.com/language/translate/v2
 
 # cat=Settings/0; type=boolean; label=Activate old backend module
-activateBackendModule=false
+activateBackendModule = 0


### PR DESCRIPTION
Because a string false becomes true with a type-hint on bool, the backend module was displayed further in v11. Therefore, the config now uses string int so that these can be type-hinted.