### PR TITLE
[FEATURE] Better translation handling

### DIFF
--- a/Classes/Command/GlossarySyncCommand.php
+++ b/Classes/Command/GlossarySyncCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace WebVision\WvDeepltranslate\Command;
 

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -61,6 +61,15 @@ class GlossaryRepository
         return $glossaryInformation;
     }
 
+    public function detectGlossaryForTranslation(
+        string $table,
+        int $elementId,
+        string $sourceLanguageId,
+        string $targetLanguageId
+    ): string {
+        return '';
+    }
+
     /**
      * @return array<string, mixed>|null
      */

--- a/Classes/Exception/GlossaryEntriesNotExistException.php
+++ b/Classes/Exception/GlossaryEntriesNotExistException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace WebVision\WvDeepltranslate\Exception;
 

--- a/Classes/Hooks/ButtonBarHook.php
+++ b/Classes/Hooks/ButtonBarHook.php
@@ -17,9 +17,6 @@ use WebVision\WvDeepltranslate\Domain\Repository\GlossaryEntryRepository;
 use WebVision\WvDeepltranslate\Domain\Repository\GlossaryRepository;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
-/**
- * @deprecated will be removed in v4
- */
 class ButtonBarHook
 {
     protected PageRepository $pageRepository;

--- a/Classes/Hooks/ButtonBarHook.php
+++ b/Classes/Hooks/ButtonBarHook.php
@@ -17,6 +17,9 @@ use WebVision\WvDeepltranslate\Domain\Repository\GlossaryEntryRepository;
 use WebVision\WvDeepltranslate\Domain\Repository\GlossaryRepository;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
+/**
+ * @deprecated will be removed in v4
+ */
 class ButtonBarHook
 {
     protected PageRepository $pageRepository;

--- a/Classes/Hooks/CmdMapLocalizationHook.php
+++ b/Classes/Hooks/CmdMapLocalizationHook.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WebVision\WvDeepltranslate\Hooks;
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use WebVision\WvDeepltranslate\Domain\Repository\GlossaryRepository;
+use WebVision\WvDeepltranslate\Domain\Repository\PageRepository;
+use WebVision\WvDeepltranslate\Exception\LanguageIsoCodeNotFoundException;
+use WebVision\WvDeepltranslate\Service\DeeplService;
+use WebVision\WvDeepltranslate\Service\LanguageService;
+
+class CmdMapLocalizationHook
+{
+    public function processCmdmap(
+        string $command,
+        string $table,
+        int $id,
+        int $value,
+        bool &$commandIsProcessed,
+        DataHandler $dataHandler,
+        $pasteUpdate
+    ): void {
+        if ($command === 'localize') {
+            $originalElement = BackendUtility::getRecord(
+                $table,
+                $id
+            );
+            $newId = $dataHandler->localize($table, $id, $value);
+            $translatedElement = BackendUtility::getRecord(
+                $table,
+                $newId
+            );
+            $commandIsProcessed = true;
+            $deeLTranslationEnabled = (bool)$GLOBALS['TCA'][$table]['ctrl']['deeplTranslation'] ?? false;
+
+            if (!$deeLTranslationEnabled) {
+                return;
+            }
+            $tableTCAColumns = $GLOBALS['TCA'][$table]['columns'];
+            $languageService = GeneralUtility::makeInstance(LanguageService::class);
+
+            $siteInformation = $languageService->getCurrentSite($table, $id);
+
+            try {
+                $sourceLanguage = $languageService->getSourceLanguage($siteInformation['site']);
+                $targetLanguage = $languageService->getTargetLanguage(
+                    $siteInformation['site'],
+                    (int)$translatedElement['sys_language_uid']
+                );
+            } catch (LanguageIsoCodeNotFoundException $e) {
+                $targetLanguage = $languageService->getTargetLanguage(
+                    $siteInformation['site'],
+                    (int)$translatedElement['sys_language_uid'],
+                    true
+                );
+                $this->cleanUpWithDefault(
+                    $table,
+                    $originalElement,
+                    $translatedElement,
+                    $dataHandler,
+                    $tableTCAColumns,
+                    $targetLanguage
+                );
+                return;
+            }
+
+            /* TODO Detect glossary here instead in service to avoid multiple calls
+            $glossary = GeneralUtility::makeInstance(GlossaryRepository::class)
+                ->detectGlossaryForTranslation($table, $id, $translatedElement['sys_language_uid']);
+            */
+            $deepLService = GeneralUtility::makeInstance(DeeplService::class);
+
+            $deepLTranslated = false;
+            $detectedSlugField = '';
+            foreach ($translatedElement as $field => $value) {
+                // reset slug to empty to auto create new with correct value
+                if (
+                    isset($tableTCAColumns[$field])
+                    && isset($tableTCAColumns[$field]['config']['type'])
+                    && $tableTCAColumns[$field]['config']['type'] === 'slug'
+                ) {
+                    $detectedSlugField = $field;
+                    continue;
+                }
+                if (
+                    !isset($tableTCAColumns[$field])
+                    || !isset($tableTCAColumns[$field]['l10n_mode'])
+                    || $tableTCAColumns[$field]['l10n_mode'] !== 'deepl'
+                ) {
+                    continue;
+                }
+                $translatedContent = $deepLService->translateRequest(
+                    $originalElement[$field],
+                    $targetLanguage['language_isocode'],
+                    $sourceLanguage['language_isocode']
+                );
+                if (!empty($translatedContent) && isset($translatedContent['translations'])) {
+                    foreach ($translatedContent['translations'] as $translation) {
+                        if ($translation['text'] != '') {
+                            $value = $translation['text'] ?? $value;
+                            $deepLTranslated = true;
+                            break;
+                        }
+                    }
+                }
+                $translatedElement[$field] = $value ?? $originalElement[$field];
+            }
+            if ($deepLTranslated) {
+                // empty slug field to auto create
+                if ($detectedSlugField !== '') {
+                    $translatedElement[$detectedSlugField] = '';
+                }
+                $data[$table][$translatedElement['uid']] = $translatedElement;
+                $innerDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+                $innerDataHandler->start($data, []);
+                $innerDataHandler->process_datamap();
+                GeneralUtility::makeInstance(PageRepository::class)
+                    ->markPageAsTranslatedWithDeepl($siteInformation['pageUid'], $targetLanguage);
+            }
+        }
+    }
+
+    private function cleanUpWithDefault(
+        string $table,
+        array $originalElement,
+        array $translatedElement,
+        DataHandler $dataHandler,
+        array $tableTCA,
+        array $targetLanguage
+    ): void {
+        // load some defaults
+        $pageId = $table === 'pages' ? $originalElement['uid'] : $originalElement['pid'];
+        $TSConfig = BackendUtility::getPagesTSconfig($pageId)['TCEMAIN.'] ?? [];
+        $tableEntries = $dataHandler->getTableEntries($table, $TSConfig);
+        if (!empty($TSConfig['translateToMessage']) && !($tableEntries['disablePrependAtCopy'] ?? false)) {
+            $translateToMsg = $this->getLanguageService()->sL($TSConfig['translateToMessage']);
+            $translateToMsg = @sprintf($translateToMsg, $targetLanguage['title']);
+        }
+
+        $detectedSlugField = '';
+        foreach ($translatedElement as $field => $value) {
+            if (
+                isset($tableTCA[$field])
+                && isset($tableTCA[$field]['config']['type'])
+                && $tableTCA[$field]['config']['type'] === 'slug'
+            ) {
+                $detectedSlugField = $field;
+                continue;
+            }
+            if (
+                !isset($tableTCA[$field])
+                || !isset($tableTCA[$field]['config']['type'])
+                || (
+                    $tableTCA[$field]['config']['type'] !== 'text'
+                    && $tableTCA[$field]['config']['type'] !== 'input'
+                )
+            ) {
+                continue;
+            }
+            if (!empty($translateToMsg) && !empty($originalElement[$field])) {
+                $translatedElement[$field] = '[' . $translateToMsg . '] ' . $originalElement[$field] ?? '';
+            } else {
+                $translatedElement[$field] = $originalElement[$field] ?? '';
+            }
+        }
+
+        $flashMessage = GeneralUtility::makeInstance(
+            FlashMessage::class,
+            LocalizationUtility::translate(
+                'automaticTranslation.fallback.message',
+                'wv_deepltranslate'
+            ),
+            LocalizationUtility::translate(
+                'automaticTranslation.fallback.title',
+                'wv_deepltranslate'
+            ),
+            FlashMessage::INFO,
+            true
+        );
+        GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier()
+            ->enqueue($flashMessage);
+
+        if ($detectedSlugField !== '') {
+            $translatedElement[$detectedSlugField] = '';
+        }
+        $data[$table][$translatedElement['uid']] = $translatedElement;
+        $innerDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $innerDataHandler->start($data, []);
+        $innerDataHandler->process_datamap();
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Localization\LanguageService
+     */
+    protected function getLanguageService(): \TYPO3\CMS\Core\Localization\LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+}

--- a/Classes/Hooks/CmdMapLocalizationHook.php
+++ b/Classes/Hooks/CmdMapLocalizationHook.php
@@ -16,7 +16,10 @@ use WebVision\WvDeepltranslate\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\WvDeepltranslate\Service\DeeplService;
 use WebVision\WvDeepltranslate\Service\LanguageService;
 
-class CmdMapLocalizationHook
+/**
+ * @internal This class is not part of `wv_deepltranslate` public API.
+ */
+final class CmdMapLocalizationHook
 {
     private static bool $flashMessageSet = false;
     public function processCmdmap(

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -87,7 +87,7 @@ class TranslateHook
                 $siteInformation['site']
             );
 
-            $targetLanguageRecord = $this->languageService->getTargetLanguage(
+            $targetLanguageRecord = $this->languageService->getLanguage(
                 $siteInformation['site'],
                 (int)$languageRecord['uid']
             );

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -18,6 +18,9 @@ use WebVision\WvDeepltranslate\Service\GoogleTranslateService;
 use WebVision\WvDeepltranslate\Service\LanguageService;
 use WebVision\WvDeepltranslate\Utility\HtmlUtility;
 
+/**
+ * @deprecated will be removed in v4
+ */
 class TranslateHook
 {
     protected DeeplService $deeplService;

--- a/Classes/Override/CommandMapPostProcessingHook.php
+++ b/Classes/Override/CommandMapPostProcessingHook.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class takes care of content translation for elements within containers
+ * @deprecated
  */
 class CommandMapPostProcessingHook extends \B13\Container\Hooks\Datahandler\CommandMapPostProcessingHook
 {

--- a/Classes/Override/CommandMapPostProcessingHook.php
+++ b/Classes/Override/CommandMapPostProcessingHook.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class takes care of content translation for elements within containers
- * @deprecated
+ * @deprecated will be removed in v4
  */
 class CommandMapPostProcessingHook extends \B13\Container\Hooks\Datahandler\CommandMapPostProcessingHook
 {

--- a/Classes/Override/DatabaseRecordList.php
+++ b/Classes/Override/DatabaseRecordList.php
@@ -19,6 +19,7 @@ use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
 /**
  * Class for rendering of Web>List module
+ * @deprecated will be removed in v4
  */
 class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList
 {

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -7,6 +7,9 @@ namespace WebVision\WvDeepltranslate\Override;
 use TYPO3\CMS\Recordlist\Controller\RecordListController;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
+/**
+ * @deprecated will be removed in v4
+ */
 class DeeplRecordListController extends RecordListController
 {
     /**

--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -35,6 +35,7 @@ use WebVision\WvDeepltranslate\Service\DeeplService;
  *
  * @internal
  * @override
+ * @deprecated will be removed in v4
  */
 class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\LocalizationController
 {

--- a/Classes/Service/LanguageService.php
+++ b/Classes/Service/LanguageService.php
@@ -98,8 +98,11 @@ class LanguageService
      * @throws LanguageRecordNotFoundException
      * @throws LanguageIsoCodeNotFoundException
      */
-    public function getTargetLanguage(Site $currentSite, int $languageId): array
-    {
+    public function getTargetLanguage(
+        Site $currentSite,
+        int $languageId,
+        bool $fallbackForDefaultTranslation = false
+    ): array {
         if ($this->siteLanguageMode) {
             $languages = array_filter($currentSite->getConfiguration()['languages'], function ($value) use ($languageId) {
                 if (!is_array($value)) {
@@ -137,7 +140,7 @@ class LanguageService
                     break;
                 }
             }
-            if ($languageIsoCode === null) {
+            if ($languageIsoCode === null && !$fallbackForDefaultTranslation) {
                 throw new LanguageIsoCodeNotFoundException(
                     sprintf(
                         'No API supported target found for language "%s" in site "%s"',
@@ -160,7 +163,7 @@ class LanguageService
         $targetLanguageRecord = $this->getRecordFromSysLanguage($languageId);
 
         $targetLanguageMapping = $this->settingsRepository->getMappings($targetLanguageRecord['uid']);
-        if ($targetLanguageMapping === '') {
+        if ($targetLanguageMapping === '' && !$fallbackForDefaultTranslation) {
             throw new LanguageIsoCodeNotFoundException(
                 sprintf(
                     'No API supported target found for language "%s"',

--- a/Classes/Service/LanguageService.php
+++ b/Classes/Service/LanguageService.php
@@ -69,28 +69,9 @@ class LanguageService
      * @return array{uid: int, title: string, language_isocode: string}
      * @throws LanguageIsoCodeNotFoundException
      */
-    public function getSourceLanguage(Site $currentSite): array
+    public function getSourceLanguage(Site $currentSite, int $languageId = 0): array
     {
-        $sourceLanguageRecord = [
-            'uid' => $currentSite->getDefaultLanguage()->getLanguageId(),
-            'title' => $currentSite->getDefaultLanguage()->getTitle(),
-            'language_isocode' => strtoupper($currentSite->getDefaultLanguage()->getTwoLetterIsoCode()),
-        ];
-
-        if (!in_array(
-            $sourceLanguageRecord['language_isocode'],
-            $this->deeplService->apiSupportedLanguages['source']
-        )) {
-            throw new LanguageIsoCodeNotFoundException(
-                sprintf(
-                    'No API supported target found for language "%s"',
-                    $sourceLanguageRecord['title']
-                ),
-                1676741965
-            );
-        }
-
-        return $sourceLanguageRecord;
+        return $this->getLanguage($currentSite, $languageId);
     }
 
     /**
@@ -98,7 +79,7 @@ class LanguageService
      * @throws LanguageRecordNotFoundException
      * @throws LanguageIsoCodeNotFoundException
      */
-    public function getTargetLanguage(
+    public function getLanguage(
         Site $currentSite,
         int $languageId,
         bool $fallbackForDefaultTranslation = false

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -67,7 +67,7 @@ class DeeplBackendUtility
     }
 
     /**
-     * @return string
+     * @deprecated will be removed in v4
      */
     public static function getGoogleApiKey(): string
     {
@@ -78,7 +78,7 @@ class DeeplBackendUtility
     }
 
     /**
-     * @return string
+     * @deprecated will be removed in v4
      */
     public static function getGoogleApiUrl(): string
     {
@@ -120,6 +120,9 @@ class DeeplBackendUtility
         self::$configurationLoaded = true;
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     public static function buildTranslateButton(
         $table,
         $id,
@@ -168,12 +171,18 @@ class DeeplBackendUtility
             . $lC . '</a> ';
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     public static function buildBackendRoute(string $route, array $parameters): string
     {
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
         return (string)$uriBuilder->buildUriFromRoute($route, $parameters);
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     private static function getIcon(string $iconFlag): Icon
     {
         $deeplTranslateIcon = sprintf('deepl-translate-%s', $iconFlag);
@@ -214,6 +223,9 @@ class DeeplBackendUtility
         return $newIcon;
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     public static function buildTranslateDropdown(
         $siteLanguages,
         $id,
@@ -290,6 +302,9 @@ class DeeplBackendUtility
         return '';
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     public static function checkCanBeTranslated(int $pageId, int $languageId): bool
     {
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
@@ -310,6 +325,9 @@ class DeeplBackendUtility
         return true;
     }
 
+    /**
+     * @deprecated will be removed in v4
+     */
     private static function getBackendUserAuthentication(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -318,7 +318,7 @@ class DeeplBackendUtility
             return false;
         }
         try {
-            $languageService->getTargetLanguage($site['site'], $languageId);
+            $languageService->getLanguage($site['site'], $languageId);
         } catch (LanguageIsoCodeNotFoundException|LanguageRecordNotFoundException $e) {
             return false;
         }

--- a/Classes/ViewHelpers/DeeplTranslateViewHelper.php
+++ b/Classes/ViewHelpers/DeeplTranslateViewHelper.php
@@ -8,6 +8,9 @@ use TYPO3\CMS\Backend\View\PageLayoutContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
+/**
+ * @deprecated will be removed in v4
+ */
 class DeeplTranslateViewHelper extends AbstractViewHelper
 {
     public function initializeArguments()

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,7 +1,9 @@
 <?php
 
 declare(strict_types=1);
-
+/**
+ * @deprecated will be removed in v4
+ */
 return [
     \WebVision\WvDeepltranslate\Domain\Model\Settings::class => [
         'tableName' => 'tx_deepl_settings',

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -60,4 +60,17 @@ if (!defined('TYPO3_MODE')) {
         '',
         'after:media'
     );
+
+    // TODO remove if in v4
+    if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)
+        ->isFeatureEnabled('deepltranslate.automaticTranslation')) {
+        $GLOBALS['TCA']['pages']['ctrl']['deeplTranslation'] = true;
+        $GLOBALS['TCA']['pages']['columns']['title']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['pages']['columns']['keywords']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['pages']['columns']['description']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['pages']['columns']['nav_title']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['pages']['columns']['subtitle']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['pages']['columns']['abstract']['l10n_mode'] = 'deepl';
+        return;
+    }
 })();

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -4,4 +4,19 @@ if (!defined('TYPO3_MODE')) {
     die();
 }
 
-$GLOBALS['TCA']['tt_content']['columns']['subheader']['l10n_mode'] = 'prefixLangTitle';
+(static function (): void {
+    // Feature Toggle
+    // TODO remove if in v4
+    if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)
+        ->isFeatureEnabled('deepltranslate.automaticTranslation')) {
+        $GLOBALS['TCA']['tt_content']['ctrl']['deeplTranslation'] = true;
+        $GLOBALS['TCA']['tt_content']['columns']['subheader']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['tt_content']['columns']['header']['l10n_mode'] = 'deepl';
+        $GLOBALS['TCA']['tt_content']['columns']['bodytext']['l10n_mode'] = 'deepl';
+        return;
+    }
+    /**
+     * @deprecated will be removed in v4
+     */
+    $GLOBALS['TCA']['tt_content']['columns']['subheader']['l10n_mode'] = 'prefixLangTitle';
+})();

--- a/Configuration/TsConfig/Page/pagetsconfig.tsconfig
+++ b/Configuration/TsConfig/Page/pagetsconfig.tsconfig
@@ -1,3 +1,4 @@
+# @deprecated will be removed in v4
 TCEMAIN {
   translateToMessage =
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -158,6 +158,13 @@
 			<trans-unit id="glossary.sync.button.all">
 				<source>Synchronise Glossaries</source>
 			</trans-unit>
+
+			<trans-unit id="automaticTranslation.fallback.message">
+				<source>For this language no DeepL translation is supported. Fallback to default translation behaviour.</source>
+			</trans-unit>
+			<trans-unit id="automaticTranslation.fallback.title">
+				<source>No DeepL support</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Tests/Functional/Services/LanguageServiceTest.php
+++ b/Tests/Functional/Services/LanguageServiceTest.php
@@ -133,7 +133,7 @@ class LanguageServiceTest extends FunctionalTestCase
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $siteInformation = $languageService->getCurrentSite('pages', 1);
 
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 2);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 2);
 
         static::assertArrayHasKey('uid', $sourceLanguageRecord);
         static::assertArrayHasKey('title', $sourceLanguageRecord);
@@ -155,7 +155,7 @@ class LanguageServiceTest extends FunctionalTestCase
 
         static::expectException(LanguageRecordNotFoundException::class);
         static::expectExceptionMessage('Language "1" not found in SiteConfig "Home"');
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 1);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 1);
     }
 
     /**
@@ -170,7 +170,7 @@ class LanguageServiceTest extends FunctionalTestCase
 
         static::expectException(LanguageIsoCodeNotFoundException::class);
         static::expectExceptionMessage('No API supported target found for language "Bosnian" in site "Home"');
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 4);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 4);
     }
 
     private function typo3VersionSkip(): void

--- a/Tests/Functional/Services/v10/LanguageServiceTest.php
+++ b/Tests/Functional/Services/v10/LanguageServiceTest.php
@@ -49,7 +49,7 @@ class LanguageServiceTest extends FunctionalTestCase
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $siteInformation = $languageService->getCurrentSite('pages', 1);
 
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 2);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 2);
 
         static::assertArrayHasKey('uid', $sourceLanguageRecord);
         static::assertArrayHasKey('title', $sourceLanguageRecord);
@@ -71,7 +71,7 @@ class LanguageServiceTest extends FunctionalTestCase
 
         static::expectException(LanguageRecordNotFoundException::class);
         static::expectExceptionMessage('No language for record with uid "5" found.');
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 5);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 5);
     }
 
     /**
@@ -84,7 +84,7 @@ class LanguageServiceTest extends FunctionalTestCase
 
         static::expectException(LanguageIsoCodeNotFoundException::class);
         static::expectExceptionMessage('No API supported target found for language "Bosnian"');
-        $sourceLanguageRecord = $languageService->getTargetLanguage($siteInformation['site'], 4);
+        $sourceLanguageRecord = $languageService->getLanguage($siteInformation['site'], 4);
     }
 
     private function typo3VersionSkip(): void

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,9 +5,7 @@ if (!defined('TYPO3_MODE')) {
 }
 
 (static function (): void {
-    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['deepltranslate.automaticTranslation'])) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['deepltranslate.automaticTranslation'] = false;
-    }
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['deepltranslate.automaticTranslation'] ??= false;
 
     //allowLanguageSynchronizationHook manipulates l10n_state
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -20,12 +20,14 @@ config.tx_extbase.persistence {
    }
 }
 
-module.tx_backend.view {
-    partialRootPaths {
-        10 = EXT:wv_deepltranslate/Resources/Private/Backend/Partials
+[feature("deepltranslate.automaticTranslation") === false]
+    module.tx_backend.view {
+        partialRootPaths {
+            10 = EXT:wv_deepltranslate/Resources/Private/Backend/Partials
+        }
     }
-}
+[END]
 
-[typo3.version < "11.5"]
+[typo3.version < "11.5" && feature("deepltranslate.automaticTranslation") === false]
     module.tx_backend.view.partialRootPaths.10 = EXT:wv_deepltranslate/Resources/Private/Backend/v10/Partials
 [END]


### PR DESCRIPTION
This feature enables automatic translation for configured tables.

For backwards compatibility a feature toggle is introduced.

With this PR and enabled Feature Toggle all built in translation
buttons and dropdown are removed, because they are obsolete.

### Workflow
Add under `$GLOBALS['SYS']['features']`

```php
'deepltranslate.automaticTranslation' => true,
```

as Core is not supporting feature toggle UI setup for extensions.

This disables all related Hooks, buttons, dropdown and enables
automatic translation for pages and tt_content as following:

`<ext>/Configuration/TCA/Overrides/pages.php`

```php
// allow page for automatic translation
$GLOBALS['TCA']['pages']['ctrl']['deeplTranslation'] = true;
// allow fields for automatic translation
$GLOBALS['TCA']['pages']['columns']['title']['l10n_mode'] = 'deepl';
$GLOBALS['TCA']['pages']['columns']['keywords']['l10n_mode'] = 'deepl';
$GLOBALS['TCA']['pages']['columns']['description']['l10n_mode'] = 'deepl';
$GLOBALS['TCA']['pages']['columns']['nav_title']['l10n_mode'] = 'deepl';
$GLOBALS['TCA']['pages']['columns']['subtitle']['l10n_mode'] = 'deepl';
$GLOBALS['TCA']['pages']['columns']['abstract']['l10n_mode'] = 'deepl';
``` 

For not capable target languages a fallback to `prefixLangTitle` is provided
with automatic prefixing and a flash message informs about not supported
language.

<img width="888" alt="Screenshot 2023-02-26 at 20 41 21" src="https://user-images.githubusercontent.com/11405116/221433138-9736efa6-d579-46fc-a98a-abe07518ace7.png">

Ideas behind this feature request:

* better handling for translations
* only one translation button
* only one language translation dropdown
* obsolete xclassing, which causes better support for other extensions, e.g. `recordlist_thumbnail`, `container`