### PR TITLE
[BUGFIX] Require PHP version in ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '3.3.0',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.1.99',
+            'php' => '7.4.0-8.2.99',
             'typo3' => '9.5.1-11.5.99',
         ],
         'conflicts' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,6 +24,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '3.3.0',
     'constraints' => [
         'depends' => [
+            'php' => '7.4.0-8.1.99',
             'typo3' => '9.5.1-11.5.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
EXT: wv_deepltranslate requires at least PHP 7.4, as stated in its `composer.json` file. However, if the TYPO3 instance is a non-Composer-based installation, the extension will be installed regardless of the used PHP version, leading to hard crashes.

To catch this case, the PHP version constraint is added to `ext_emconf.php`.

Fixes: #170