### PR TITLE
[BUGFIX] Use correct POST body for submitting the glossary

### DIFF
--- a/Classes/Service/Client/Client.php
+++ b/Classes/Service/Client/Client.php
@@ -96,15 +96,10 @@ final class Client implements ClientInterface
      */
     public function request($url, $body = '', $method = 'POST')
     {
-        $resource = null;
-        if (!empty($body)) {
-            $streamBody = sprintf('data://text/plain,%s', $body);
-            $resource = fopen($streamBody, 'r');
-        }
         $request = new Request(
             $url,
             $method,
-            $resource,
+            null,
             [
                 'Content-Type' => 'application/x-www-form-urlencoded',
                 'Authorization' => sprintf('DeepL-Auth-Key %s', $this->authKey),
@@ -113,8 +108,9 @@ final class Client implements ClientInterface
         );
 
         $options = [
-          //  '_body_as_string' =>
+            'body' => $body,
         ];
+
         // read TYPO3 Proxy settings and adapt
         if (!empty($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'])) {
             $httpProxy = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'];


### PR DESCRIPTION
I have glossary with ~4900 entries. When trying to submit it to DeepL, I received an exception:

![Bildschirmfoto vom 2023-03-24 10-27-06](https://user-images.githubusercontent.com/16088567/227493966-32265b47-d9f9-4d20-a027-de41e28b16d2.png)

I could solve it, by moving the body content from the Request to the options.

For any reason, guzzle's `PrepareBodyMiddleware` was not able to calculate the correct content length for your way.