### PR TITLE
[FIX] Trim source and target strings

### DIFF
--- a/Classes/Service/DeeplGlossaryService.php
+++ b/Classes/Service/DeeplGlossaryService.php
@@ -126,7 +126,7 @@ class DeeplGlossaryService
 
         $formattedEntries = [];
         foreach ($entries as $entry) {
-            $formattedEntries[] = sprintf("%s\t%s", $entry['source'], $entry['target']);
+            $formattedEntries[] = sprintf("%s\t%s", trim($entry['source']), trim($entry['target']));
         }
 
         $paramsArray = [


### PR DESCRIPTION
Prevent an error during sync by sending non-trimmed strings