### PR TITLE
[TASK] Use `core-testing-*` images from `ghcr.io`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -29,6 +29,7 @@ setUpDockerComposeDotEnv() {
         echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}"
         echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}"
         echo "DATABASE_DRIVER=${DATABASE_DRIVER}"
+        echo "IMAGE_PREFIX=${IMAGE_PREFIX}"
         echo "DEEPL_API_KEY=''"
         echo "DEEPL_HOST='127.0.0.1'"
         echo "DEEPL_PORT='3000'"
@@ -184,6 +185,7 @@ EXTRA_TEST_OPTIONS=""
 SCRIPT_VERBOSE=0
 CGLCHECK_DRY_RUN=""
 DATABASE_DRIVER=""
+IMAGE_PREFIX="ghcr.io/typo3/"
 
 # Option parsing
 # Reset in case getopts has been used previously in the shell
@@ -393,10 +395,10 @@ case ${TEST_SUITE} in
         docker-compose down
         ;;
     update)
-        # pull typo3/core-testing-*:latest versions of those ones that exist locally
-        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
-        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
-        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        # pull ${IMAGE_PREFIX}core-testing-*:latest versions of those ones that exist locally
+        docker images ${IMAGE_PREFIX}core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" ${IMAGE_PREFIX}core-testing-* images (those tagged as <none>)
+        docker images ${IMAGE_PREFIX}core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
         ;;
     *)
         echo "Invalid -s option argument ${TEST_SUITE}" >&2

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   #
   # Based on https://github.com/DeepLcom/deepl-mock build as public image by Stefan Bürk <stefan@buerk.tech>.
   deeplapi:
-    image: sbuerk/sbuerk-testing-deeplapimockserver:0.0.1
+    image: sbuerk/sbuerk-testing-deeplapimockserver:latest
 
   mariadb10:
     image: mariadb:10.5.6
@@ -31,7 +31,7 @@ services:
 
 
 #  cgl_git:
-#    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+#    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
 #    user: "${HOST_UID}"
 #    volumes:
 #      - ${CORE_ROOT}:${CORE_ROOT}
@@ -45,7 +45,7 @@ services:
 #      "
 
   cgl_all:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -59,7 +59,7 @@ services:
       "
 
   check_bom:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -73,7 +73,7 @@ services:
       "
 
   check_exception_codes:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -87,7 +87,7 @@ services:
       "
 
   check_test_methods_prefix:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -102,7 +102,7 @@ services:
 
 
   check_rst:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -116,7 +116,7 @@ services:
       "
 
   composer_update:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -133,7 +133,7 @@ services:
       "
 
   functional_mariadb10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - mariadb10
@@ -164,7 +164,11 @@ services:
         while ! nc -z mariadb10 3306; do
           sleep 1;
         done;
-        sleep 2;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
         echo Database is up;
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
@@ -179,7 +183,7 @@ services:
       "
 
   functional_mysql80:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - mysql80
@@ -210,7 +214,11 @@ services:
         while ! nc -z mysql80 3306; do
           sleep 1;
         done;
-        sleep 2;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
         echo Database is up;
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
@@ -225,7 +233,7 @@ services:
       "
 
   functional_postgres10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - postgres10
@@ -256,7 +264,11 @@ services:
         while ! nc -z postgres10 5432; do
           sleep 1;
         done;
-        sleep 2;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
         echo Database is up;
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
@@ -271,7 +283,7 @@ services:
       "
 
   functional_sqlite:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - deeplapi
@@ -295,7 +307,11 @@ services:
           set -x
         fi
         rm -rf .Build/Web/typo3temp/var/tests/functional-*;
-        sleep 10;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
@@ -309,7 +325,7 @@ services:
       "
 
   lint_php:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -324,7 +340,7 @@ services:
       "
 
   lint_typoscript:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -339,7 +355,7 @@ services:
       "
 
   phpstan:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -355,7 +371,7 @@ services:
       "
 
   phpstan_generate_baseline:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -371,7 +387,7 @@ services:
       "
 
   unit:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -133,7 +133,6 @@ class TranslateHook
         string $customMode,
         array $sourceLanguageRecord
     ): string {
-
         // mode deepl
         if ($customMode == 'deepl') {
             $response = $this->deeplService->translateRequest(

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -28,7 +28,7 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '9.5.1-11.5.99',
         ],
         'conflicts' => [
-            'recordlist_thumbnail' => '*'
+            'recordlist_thumbnail' => '*',
         ],
         'suggests' => [],
     ],


### PR DESCRIPTION
This change adjusts `Build/Scripts/runTests.sh` and
`Build/testing-docker/docker-compose.yml` to add a
docker image prefix. This prefix is hardcoded to use
the TYPO3 core-testing images from the TYPO3 GitHub
Container Registry by setting the prefix to `ghcr.io`.

DeepL Mock Api image is raised to use `latest` tag.
Functional container scripts are extended with a
deeplmockapiserver start check.

See: https://github.com/orgs/TYPO3/packages