### PR TITLE
Update ButtonBarHook.php

### DIFF
--- a/Classes/Hooks/ButtonBarHook.php
+++ b/Classes/Hooks/ButtonBarHook.php
@@ -37,7 +37,7 @@ class ButtonBarHook
             );
 
             if (
-                $page['module'] === 'glossary'
+                isset($page['module']) && $page['module'] === 'glossary'
                 && $this->getBackendUserAuthentication()
                     ->check('tables_modify', 'tx_wvdeepltranslate_glossaryentry')
             ) {


### PR DESCRIPTION
Fix for the following error:  On click of the pageroot in the TYPO3 pagetree, the following error shows up.

PHP Warning: Trying to access array offset on value of type null in /var/www/html/typo3/public/typo3conf/ext/wv_deepltranslate/Classes/Hooks/ButtonBarHook.php line 40

Closes #205 