### PR TITLE
[BUGFIX] Exclude fields in upgrade wizards

### DIFF
--- a/Classes/Upgrades/GlossaryUpgradeWizard.php
+++ b/Classes/Upgrades/GlossaryUpgradeWizard.php
@@ -66,6 +66,8 @@ class GlossaryUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
         $updateGlossary = [];
         foreach ($result as $item) {
             unset($item['description']);
+            unset($item['starttime']);
+            unset($item['endtime']);
             $updateGlossary[] = $item;
         }
 

--- a/Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_tables.sql
+++ b/Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_tables.sql
@@ -12,6 +12,8 @@ CREATE TABLE tx_wvdeepltranslate_domain_model_glossaries
 	l10n_source      int unsigned      default 0  not null,
 	l10n_state       text                         null,
 	l10n_diffsource  mediumblob                   null,
+	starttime int unsigned      default 0 not null,
+	endtime int unsigned      default 0 not null,
 
 	term        varchar(255),
 	description text,

--- a/Tests/Functional/Updates/Fixtures/TableToMigrate.xml
+++ b/Tests/Functional/Updates/Fixtures/TableToMigrate.xml
@@ -38,6 +38,8 @@
         <description>Englisch - Lorem ipsum dolor sit ame</description>
         <sys_language_uid>0</sys_language_uid>
         <term>Hello</term>
+        <starttime>0</starttime>
+        <endtime>0</endtime>
     </tx_wvdeepltranslate_domain_model_glossaries>
     <tx_wvdeepltranslate_domain_model_glossaries>
         <uid>2</uid>
@@ -45,6 +47,8 @@
         <description>Deutsch - Lorem ipsum dolor sit ame</description>
         <sys_language_uid>1</sys_language_uid>
         <term>Welt</term>
+        <starttime>0</starttime>
+        <endtime>0</endtime>
     </tx_wvdeepltranslate_domain_model_glossaries>
     <tx_wvdeepltranslate_domain_model_glossariessync>
         <uid>1</uid>


### PR DESCRIPTION
Fields like startime and endtime are no longer used in glossary entry tables and can be ignored by the update script.

Close #208 