### PR TITLE
[TASK] Move ajax extension config check in own class

### DIFF
--- a/Classes/Controller/Backend/AjaxController.php
+++ b/Classes/Controller/Backend/AjaxController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Controller\Backend;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Configuration;
+
+// @todo use #[Controller] if 12.4+ only support is established, see: TYPO3\CMS\Backend\Attribute\Controller;
+final class AjaxController
+{
+    private Configuration $configuration;
+
+    public function __construct()
+    {
+        // @todo Consider to make this handed over through DI.
+        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
+    }
+
+    /**
+     * check deepl Settings (url,apikey).
+     */
+    public function checkExtensionConfiguration(ServerRequestInterface $request): JsonResponse
+    {
+        $configurationStatus = [
+            'status' => true,
+            'message' => '',
+        ];
+        if ($this->configuration->getApiKey() == null
+            && $this->configuration->getApiUrl() == null
+        ) {
+            $configurationStatus['status']  = false;
+            $configurationStatus['message'] = 'Deepl settings not enabled';
+        }
+
+        return new JsonResponse($configurationStatus);
+    }
+}

--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
-use WebVision\WvDeepltranslate\Configuration;
 use WebVision\WvDeepltranslate\Service\DeeplService;
 
 /**
@@ -46,14 +45,12 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
     protected DeeplService $deeplService;
 
     protected PageRenderer $pageRenderer;
-    private Configuration $configuration;
 
     public function __construct()
     {
         parent::__construct();
 
         $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
         $this->deeplService = GeneralUtility::makeInstance(DeeplService::class);
         $this->pageRenderer->addInlineLanguageLabelFile('EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf');
     }
@@ -264,26 +261,6 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $dataHandler->start([], $cmd);
         $dataHandler->process_cmdmap();
-    }
-
-    /**
-     * check deepl Settings (url,apikey).
-     * @param ServerRequestInterface $request
-     * @return array
-     */
-    public function checkdeeplSettings(ServerRequestInterface $request)
-    {
-        $result = [];
-        if ($this->configuration->getApiKey() != null && $this->configuration->getApiUrl() != null) {
-            $result['status'] = 'true';
-        } else {
-            $result['status']  = 'false';
-            $result['message'] = 'Deepl settings not enabled';
-        }
-
-        $result = json_encode($result);
-        echo $result;
-        exit;
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -3,13 +3,13 @@
  * Definitions for routes provided by EXT:deepl
  * Contains all AJAX-based routes for entry points
  *
- * Currently the "access" property is only used so no token creation + validation is made
+ * Currently, the "access" property is only used so no token creation + validation is made
  * but will be extended further.
  */
+
 return [
-    // Localize the records
-    'records_localizedeepl' => [
-        'path' => '/records/localizedeepl',
-        'target' => WebVision\WvDeepltranslate\Override\LocalizationController::class . '::checkdeeplSettings',
+    'deepl_check_configuration' => [
+        'path' => '/deepl/check-configuration',
+        'target' => WebVision\WvDeepltranslate\Controller\Backend\AjaxController::class . '::checkExtensionConfiguration',
     ],
 ];

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 return [
     'apps-pagetree-folder-contains-glossary' => [
         'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,

--- a/Resources/Public/JavaScript/Localization.js
+++ b/Resources/Public/JavaScript/Localization.js
@@ -483,7 +483,7 @@ define('TYPO3/CMS/Backend/Localization', [
      */
     Localization.deeplSettings = function (pageId, languageId, uidList) {
       return $.ajax({
-        url: TYPO3.settings.ajaxUrls['records_localizedeepl'],
+        url: TYPO3.settings.ajaxUrls['deepl_check_configuration'],
         data: {
           pageId: pageId,
           srcLanguageId: Localization.settings.language,


### PR DESCRIPTION
A new Ajax function does not belong in an XClass/Override. It does not belong there thematically.