### PR TITLE
[TASK] Avoid `rowCount()` for select query

### DIFF
--- a/Classes/Upgrades/GlossaryUpgradeWizard.php
+++ b/Classes/Upgrades/GlossaryUpgradeWizard.php
@@ -226,11 +226,13 @@ class GlossaryUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_wvdeepltranslate_domain_model_glossaries');
         $queryBuilder->getRestrictions()->removeAll();
-        $statement = $queryBuilder
-            ->select('*')
-            ->from('tx_wvdeepltranslate_domain_model_glossaries');
+        $count = (int)$queryBuilder
+            ->count('*')
+            ->from('tx_wvdeepltranslate_domain_model_glossaries')
+            ->execute()
+            ->fetchColumn(0);
 
-        return $statement->execute()->rowCount() > 0;
+        return $count > 0;
     }
 
     /**


### PR DESCRIPTION
Using the `rowCount(` method for an `SELECT` query
is not reliable. That's already documented in the
TYPO3 documentation. It's recommended to use a `COUNT()`
query instead.

See: https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Database/Statement/Index.html#rowcount

This change uses now a `COUNT(*)` based  query to avoid
the unreliable `rowCount()` method in the corresponding
`WebVision\WvDeepltranslate\Upgrades\GlossaryUpgradeWizard`.

This will be fixed in main within other stuffs and this
is only the manual backport for the 3.x branch.

Releases: 3.x
