### PR TITLE
Fix Problem with translation no glossary given

### DIFF
--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -214,6 +214,7 @@ class GlossaryRepository
      *     glossary_lastsync: int,
      *     glossary_ready: int
      * }
+     * @throws DBALException
      */
     public function getGlossaryBySourceAndTarget(
         string $sourceLanguage,
@@ -234,7 +235,7 @@ class GlossaryRepository
         if (strlen($lowerTargetLang) > 2) {
             $lowerTargetLang = substr($lowerTargetLang, 0, 2);
         }
-        return $this->getGlossary($lowerSourceLang, $lowerTargetLang, $page['uid'], true);
+        return $this->getGlossary($lowerSourceLang, $lowerTargetLang, $page['uid'], true) ?? [];
     }
 
     /**

--- a/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
@@ -170,7 +170,6 @@
         <f:if condition="{deeplLanguages -> f:count()} > 0">
             <div class="row row-cols-auto align-items-end g-3 mb-3">
                 <div class="col row">
-                    <label class="col-sm-4 col">{f:translate(key: 'backend.label', extensionName: 'wv_deepltranslate')}</label>
                     <div class="col col-sm-8">
                         <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
                             <option><f:translate key="pages.glossary.translate" extensionName="wv_deepltranslate" /></option>


### PR DESCRIPTION
If no glossary is given, the TranslateHook crashes because of wrong return param. This fix corrects the return value to an empty array.

Additionally, the label for translation dropdown is removed due to backend UI limitations.