### PR TITLE
[TASK] Add TYPO3 v12 support to Build/Scripts/runTests.sh

### DIFF
--- a/.ddev/commands/web/run-tests
+++ b/.ddev/commands/web/run-tests
@@ -6,7 +6,7 @@
 ## Flags: [{"Name":"version","Shorthand":"v","Type":"string","DefValue":"all","Usage":"Switch of TYPO3 version (11)"},{"Name":"filter","Shorthand":"f","Type":"string","DefValue":"MySpecialTest","Usage":"filter Test runnings"},{"Name":"test","Shorthand":"t","Type":"string","Usage":"Test mode (all|func|unit)","DefValue":"all","Name":"only-test","Shorthand":"o","Usage":"Flag triggers only tests without version update","NoOptDefVal":"1"}]
 ## ProjectTypes: typo3
 
-versions=(all 11)
+versions=(all 12 11)
 testcases=(all func unit)
 selectedVersion=
 testCase=all
@@ -62,6 +62,16 @@ run_functional() {
     fi
 }
 
+run_functional10() {
+    fileName=".test-results/functional-${currentVersion}.txt"
+    echo "" >$fileName
+    if [ "${filter}" = "" ]; then
+        composer test:php:functional10 -- >>$fileName
+    else
+        composer test:php:functional10 -- --filter="$filter" $fileName
+    fi
+}
+
 run_unit() {
     fileName=".test-results/unit-${currentVersion}.txt"
     echo "" >$fileName
@@ -72,17 +82,31 @@ run_unit() {
     fi
 }
 
+run_unit10() {
+    fileName=".test-results/unit-${currentVersion}.txt"
+    echo "" >$fileName
+    if [ "${filter}" = "" ]; then
+        composer test:php:unit10 >>$fileName
+    else
+        composer test:php:unit10 -- --filter="$filter" >>$fileName
+    fi
+}
+
 run_test() {
     case $testCase in
     all)
-        run_functional
-        run_unit
+        [[ "${currentVersion}" -eq 11 ]] && run_functional
+        [[ "${currentVersion}" -eq 11 ]] && run_unit
+        [[ "${currentVersion}" -eq 12 ]] && run_functional10
+        [[ "${currentVersion}" -eq 12 ]] && run_unit10
         ;;
     unit)
-        run_unit
+        [[ "${currentVersion}" -eq 11 ]] && run_unit
+        [[ "${currentVersion}" -eq 12 ]] && run_unit10
         ;;
     func)
-        run_functional
+        [[ "${currentVersion}" -eq 11 ]] && run_functional
+        [[ "${currentVersion}" -eq 12 ]] && run_functional10
         ;;
     esac
 }

--- a/Build/Scripts/composer-for-core-version.sh
+++ b/Build/Scripts/composer-for-core-version.sh
@@ -20,6 +20,16 @@ composer_update() {
     git restore composer.json
 }
 
+update_v12() {
+    echo -e "💪 Enforce TYPO3 v12"
+    composer require --no-update \
+        "typo3/cms-core":"^12.4"
+
+    echo -e "💪 Enforce PHPUnit 9.x"
+    composer req --dev --no-update \
+        "phpunit/phpunit":"^10.1"
+}
+
 update_v11() {
     echo -e "💪 Enforce TYPO3 v11"
     composer require --no-update \
@@ -31,6 +41,11 @@ update_v11() {
 }
 
 case "$1" in
+12)
+    composer_cleanup
+    update_v12
+    composer_update
+    ;;
 11)
     composer_cleanup
     update_v11

--- a/Build/phpunit/FunctionalTests-10.xml
+++ b/Build/phpunit/FunctionalTests-10.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a functional test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/FunctionalTests.xml.
+    Note FunctionalTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+    phpunit v10.1 compatible version.
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+    backupGlobals="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    bootstrap="FunctionalTestsBootstrap.php"
+    cacheDirectory=".phpunit.cache"
+    cacheResult="false"
+    colors="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnDeprecation="true"
+    failOnNotice="true"
+    failOnRisky="true"
+    failOnWarning="true"
+    requireCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="Functional tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory suffix="Test.php">../../Tests/Functional/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE"/>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+         -->
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Build/phpunit/UnitTests-10.xml
+++ b/Build/phpunit/UnitTests-10.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+    phpunit v10.1 compatible version.
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+    backupGlobals="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    bootstrap="UnitTestsBootstrap.php"
+    cacheDirectory=".phpunit.cache"
+    cacheResult="false"
+    colors="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnDeprecation="true"
+    failOnNotice="true"
+    failOnRisky="true"
+    failOnWarning="true"
+    requireCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory suffix="Test.php">../../Tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE"/>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -290,7 +290,7 @@ services:
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
     tmpfs:
-      - ${ROOT_DIR}/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
+      - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
     environment:
       typo3DatabaseDriver: pdo_sqlite
       DEEPL_API_KEY: ''
@@ -321,6 +321,198 @@ services:
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
           .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        fi
+      "
+
+  functional_mariadb10_phpunit10:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - mariadb10
+      - deeplapi
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: "${DATABASE_DRIVER}"
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mariadb10
+      DEEPL_API_KEY: ''
+      DEEPL_HOST: 'deeplapi'
+      DEEPL_PORT: '3000'
+      DEEPL_SCHEME: 'http'
+      DEEPL_MOCKSERVER_USED: 1
+    working_dir: ${ROOT_DIR}/
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        rm -rf .Build/Web/typo3temp/var/tests/functional-*;
+        echo Waiting for database start...;
+        while ! nc -z mariadb10 3306; do
+          sleep 1;
+        done;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  functional_mysql80_phpunit10:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - mysql80
+      - deeplapi
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: "${DATABASE_DRIVER}"
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mysql80
+      DEEPL_API_KEY: ''
+      DEEPL_HOST: 'deeplapi'
+      DEEPL_PORT: '3000'
+      DEEPL_SCHEME: 'http'
+      DEEPL_MOCKSERVER_USED: 1
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        rm -rf .Build/Web/typo3temp/var/tests/functional-*;
+        echo Waiting for database start...;
+        while ! nc -z mysql80 3306; do
+          sleep 1;
+        done;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  functional_postgres10_phpunit10:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - postgres10
+      - deeplapi
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: pdo_pgsql
+      typo3DatabaseName: bamboo
+      typo3DatabaseUsername: funcu
+      typo3DatabaseHost: postgres10
+      typo3DatabasePassword: funcp
+      DEEPL_API_KEY: ''
+      DEEPL_HOST: 'deeplapi'
+      DEEPL_PORT: '3000'
+      DEEPL_SCHEME: 'http'
+      DEEPL_MOCKSERVER_USED: 1
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        rm -rf .Build/Web/typo3temp/var/tests/functional-*;
+        echo Waiting for database start...;
+        while ! nc -z postgres10 5432; do
+          sleep 1;
+        done;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        fi
+      "
+
+  functional_sqlite_phpunit10:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - deeplapi
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    tmpfs:
+      - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
+    environment:
+      typo3DatabaseDriver: pdo_sqlite
+      DEEPL_API_KEY: ''
+      DEEPL_HOST: 'deeplapi'
+      DEEPL_PORT: '3000'
+      DEEPL_SCHEME: 'http'
+      DEEPL_MOCKSERVER_USED: 1
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        rm -rf .Build/Web/typo3temp/var/tests/functional-*;
+        echo Waiting for deeplapimockserver start...;
+        while ! nc -z deeplapi 3000; do
+          sleep 1;
+        done;
+        sleep 4;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/bin/phpunit -c Build/phpunit/FunctionalTests-10.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
         fi
       "
 
@@ -408,5 +600,29 @@ services:
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
           .Build/bin/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+  unit10:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/phpunit/UnitTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/bin/phpunit -c Build/phpunit/UnitTests-10.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         fi
       "

--- a/composer.json
+++ b/composer.json
@@ -74,11 +74,11 @@
 		"typo3/cms-install": "^11.5 || ^12.4"
 	},
 	"require-dev": {
-		"b13/container": "^1.6",
+		"b13/container": "^2.2.2",
 		"friendsofphp/php-cs-fixer": "^3.14.1",
 		"helhum/typo3-console": "^7.1.6 || ^8.0.2",
-		"helmich/phpunit-json-assert": "3.4.3",
-		"helmich/typo3-typoscript-lint": "^2.5",
+		"helmich/phpunit-json-assert": "^3.4.3 || ^3.5.1",
+		"helmich/typo3-typoscript-lint": "^3.1.0",
 		"nikic/php-parser": "^4.15.1",
 		"phpstan/phpstan": "^1.3",
 		"phpunit/phpunit": "^9.6.8 || ^10.1",
@@ -116,6 +116,8 @@
 			"@test:php:functional"
 		],
 		"test:php:unit": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
+		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml",
+		"test:php:unit10": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests-10.xml",
+		"test:php:functional10": "@test:php:unit --configuration Build/phpunit/FunctionalTests-10.xml"
 	}
 }


### PR DESCRIPTION
This change adds basic support to test against
TYPO3 v12 core. That includes adding corresponding
switches to `Build/Scripts/runTests.sh` and the
ddev `runtests.sh` script.

TYPO3 v12 testing will be done with PHPUnit v10
only, therefore we add corresponding configuration
files aside of the PHPUnit v9 config files.

**Note:** TYPO3 v12 tests are left out per intention
          for now, because they would not be green
          yet.

Used command(s):

```shell
composer require --dev --no-update \
    "b13/container":"^2.2.2" \
    "helmich/typo3-typoscript-lint":"^3.1.0" \
    "helmich/phpunit-json-assert":"^3.4.3 || ^3.5.1"
```

Resolves: #242
