### PR TITLE
[TASK] Display correct versions in core switch script

### DIFF
--- a/Build/Scripts/composer-for-core-version.sh
+++ b/Build/Scripts/composer-for-core-version.sh
@@ -25,7 +25,7 @@ update_v12() {
     composer require --no-update \
         "typo3/cms-core":"^12.4"
 
-    echo -e "💪 Enforce PHPUnit 9.x"
+    echo -e "💪 Enforce PHPUnit ^10.1"
     composer req --dev --no-update \
         "phpunit/phpunit":"^10.1"
 }
@@ -35,7 +35,7 @@ update_v11() {
     composer require --no-update \
         "typo3/cms-core":"^11.5"
 
-    echo -e "💪 Enforce PHPUnit 9.x"
+    echo -e "💪 Enforce PHPUnit ^9.6.8"
     composer req --dev --no-update \
         "phpunit/phpunit":"^9.6.8"
 }
@@ -52,7 +52,7 @@ case "$1" in
     composer_update
     ;;
 *)
-    echo -e "🌀 Usage: ddev update-to {11}" >&2
+    echo -e "🌀 Usage: ddev update-to (11|12)" >&2
     exit 0
     ;;
 esac


### PR DESCRIPTION
For adding basic TYPO3 v12 core testing support
some commands have been copied. Sadly, not the
correct versions have been used for the output.
That means, it does not matches what is installed.

This change now fixes this to have the echo test
aligned to what is done. That avoids confusion.

Releases: main
