### PR TITLE
[TASK] Streamline doctrine/dbal usages

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -36,34 +36,14 @@ parameters:
 			path: ../../Classes/Controller/GlossarySyncController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetch\\(\\)\\.$#"
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryEntryRepository\\:\\:findEntriesByGlossary\\(\\) should return array\\<string, mixed\\> but returns array\\<int, array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: ../../Classes/Domain/Repository/GlossaryEntryRepository.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetchAll\\(\\)\\.$#"
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryEntryRepository\\:\\:findEntryByUid\\(\\) should return array\\<non\\-empty\\-string, mixed\\> but returns array\\<string, mixed\\>\\.$#"
 			count: 1
 			path: ../../Classes/Domain/Repository/GlossaryEntryRepository.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetch\\(\\)\\.$#"
-			count: 1
-			path: ../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetchAll\\(\\)\\.$#"
-			count: 1
-			path: ../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
-			count: 2
-			path: ../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
-			count: 3
-			path: ../../Classes/Domain/Repository/GlossaryRepository.php
 
 		-
 			message: "#^Cannot call method getTimestamp\\(\\) on DateTimeImmutable\\|false\\.$#"
@@ -86,6 +66,11 @@ parameters:
 			path: ../../Classes/Domain/Repository/GlossaryRepository.php
 
 		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossary\\(\\) should return array\\{uid\\: int, glossary_name\\: string, glossary_id\\: string, glossary_lastsync\\: int, glossary_ready\\: int\\}\\|null but returns non\\-empty\\-array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: ../../Classes/Domain/Repository/GlossaryRepository.php
+
+		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossaryBySourceAndTarget\\(\\) should return array\\{uid\\: int, glossary_name\\: string, glossary_id\\: string, glossary_lastsync\\: int, glossary_ready\\: int\\} but returns array\\{uid\\: int, glossary_name\\: string, glossary_id\\: string, glossary_lastsync\\: int, glossary_ready\\: int\\}\\|null\\.$#"
 			count: 1
 			path: ../../Classes/Domain/Repository/GlossaryRepository.php
@@ -96,7 +81,7 @@ parameters:
 			path: ../../Classes/Domain/Repository/GlossaryRepository.php
 
 		-
-			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getLocalizedEntries\\(\\) should return array\\<int, array\\{uid\\: int, term\\: string, l10n_parent\\: int\\}\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getLocalizedEntries\\(\\) should return array\\<int, array\\{uid\\: int, term\\: string, l10n_parent\\: int\\}\\> but returns array\\<int\\|string, array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: ../../Classes/Domain/Repository/GlossaryRepository.php
 
@@ -122,11 +107,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$pageUid of method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossary\\(\\) expects int, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 1
-			path: ../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:andX\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: ../../Classes/Domain/Repository/GlossaryRepository.php
 
@@ -176,11 +156,6 @@ parameters:
 			path: ../../Classes/Hooks/DeeplPreviewFlagGeneratePageHook.php
 
 		-
-			message: "#^Offset 'pid' does not exist on array\\{uid\\: int\\}\\.$#"
-			count: 1
-			path: ../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
-
-		-
 			message: "#^Parameter \\#1 \\$message of class TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: ../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
@@ -192,11 +167,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$title of class TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: ../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
-
-		-
-			message: "#^Variable \\$glossary in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: ../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
 
@@ -224,16 +194,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
 			count: 1
 			path: ../../Classes/Override/DeeplRecordListController.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetch\\(\\)\\.$#"
-			count: 1
-			path: ../../Classes/Override/LocalizationController.php
-
-		-
-			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Override\\\\LocalizationController\\:\\:checkdeeplSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Classes/Override/LocalizationController.php
 
 		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Override\\\\LocalizationController\\:\\:process\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
@@ -334,11 +294,6 @@ parameters:
 			message: "#^Property WebVision\\\\WvDeepltranslate\\\\Service\\\\LanguageService\\:\\:\\$possibleLangMatches type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../Classes/Service/LanguageService.php
-
-		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
-			count: 1
-			path: ../../Classes/Utility/DeeplBackendUtility.php
 
 		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Utility\\\\DeeplBackendUtility\\:\\:buildBackendRoute\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"

--- a/Classes/Domain/Repository/GlossaryEntryRepository.php
+++ b/Classes/Domain/Repository/GlossaryEntryRepository.php
@@ -35,11 +35,11 @@ class GlossaryEntryRepository
             ]
         );
 
-        return $result->fetchAll() ?: [];
+        return $result->fetchAllAssociative() ?: [];
     }
 
     /**
-     * @return array{uid: int}
+     * @return array<non-empty-string, mixed>
      */
     public function findEntryByUid(int $uid): array
     {
@@ -54,6 +54,7 @@ class GlossaryEntryRepository
             ]
         );
 
-        return $result->fetch() ?: [];
+        // @todo Should we not better returning null instead of an empty array if nor recourd could be retrieved ?
+        return $result->fetchAssociative() ?: [];
     }
 }

--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -8,29 +8,32 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+// @todo Consider to rename/move this as service class.
 final class PageRepository
 {
     /**
      * @param array{uid: int} $targetLanguage
+     * @todo Is the array shape for $targetLangauge correct/complete ?
      */
     public function markPageAsTranslatedWithDeepl(int $pageId, array $targetLanguage): void
     {
         GeneralUtility::makeInstance(ConnectionPool::class)
-        ->getConnectionForTable('pages')
-        ->update(
-            'pages',
-            [
-                'tx_wvdeepltranslate_content_not_checked' => 1,
-                'tx_wvdeepltranslate_translated_time' => time(),
-            ],
-            [
-                'l10n_parent' => $pageId,
-                'sys_language_uid' => $targetLanguage['uid'],
-            ],
-            [
-                Connection::PARAM_INT,
-                Connection::PARAM_INT,
-            ]
-        );
+            ->getConnectionForTable('pages')
+            ->update(
+                'pages',
+                [
+                    'tx_wvdeepltranslate_content_not_checked' => 1,
+                    // @todo Consider to use $GLOBALS['EXEC_TIME'] or $GLOBALS['SIM_EXEC_TIME'] instead of time().
+                    'tx_wvdeepltranslate_translated_time' => time(),
+                ],
+                [
+                    'l10n_parent' => $pageId,
+                    'sys_language_uid' => $targetLanguage['uid'],
+                ],
+                [
+                    Connection::PARAM_INT, // @todo With 12.4+ minimal support this can be omitted.
+                    Connection::PARAM_INT, // @todo With 12.4+ minimal support this can be omitted.
+                ]
+            );
     }
 }

--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -148,7 +148,7 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
             '*'
         );
 
-        while ($row = $result->fetch()) {
+        while ($row = $result->fetchAssociative()) {
             BackendUtility::workspaceOL('tt_content', $row, -99, true);
             if (!$row || VersionState::cast($row['t3ver_state'])->equals(VersionState::DELETE_PLACEHOLDER)) {
                 continue;

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -214,7 +214,8 @@ class DeeplBackendUtility
                     (int)self::getBackendUserAuthentication()->workspace
                 )
             );
-        $statement = $queryBuilder->select('uid', $languageField)
+        $statement = $queryBuilder
+            ->select('uid', $languageField)
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq(
@@ -222,7 +223,7 @@ class DeeplBackendUtility
                     $queryBuilder->createNamedParameter($id, Connection::PARAM_INT)
                 )
             )
-            ->execute();
+            ->executeQuery();
         while ($pageTranslation = $statement->fetchAssociative()) {
             unset($availableTranslations[(int)$pageTranslation[$languageField]]);
         }


### PR DESCRIPTION
This change streamlines the code base to
a modern usage of doctrine/dbal to avoid
deprecated methods and constructs.

Some `@todo` comments have been added to
document future improvements and stuff
which should be considered or solved.

Tasks:
------

* Use `fetchAssociative()` instead of `fetch()`.
* Use `fetchAllAssociative()` instead of `fetchAll()`.
* Use `and()` instead of `andX()`.
* Use `or()` instead of `orX()`.
* Use `executeQuery()` for queries returning a result
  set, e.g. SELECT and COUNT queries.
* Use `executeStatement()` for quereis returning a
  affected row number, e.g. INSERT, UPDATE and DELETE
  queries.
* Use placeholder to ensure proper dbms value quoting
  even for static values.

**NOTE:** Entries have been added to the phpstan
          baseline. Argument and return type array
	  shapes should be reviewed and adjusted
          dedicated patches and eventually mitigated
          by introducing real objects instead of
          array structures.

Used command(s):

```shell
Build/Scripts/runTests.sh -s phpstanGenerateBaseline
```

Resolves: #248
Releases: main
