### PR TITLE
[TASK] Remove obsolete version check from siteconfiguration tca

### DIFF
--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -1,14 +1,6 @@
 <?php
 
 (static function () {
-    $typo3VersionArray = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionStringToArray(
-        \TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version()
-    );
-
-    // before v11 we dont use this field
-    if (version_compare((string)$typo3VersionArray['version_main'], '11', '<')) {
-        return;
-    }
 
     $ll = function (string $identifier) {
         return 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:' . $identifier;


### PR DESCRIPTION
The siteconfiguration related tca override contained a
version switch to add the custom extension field only
for TYPO3 v11 and up.

Beside it should considered to drop that custom field,
the version check is removed because it is guaranteed
by the composer TYPO3 version constraint of the main
branch.

Releases: main
