### PR TITLE
[TASK] Introduce core version based RecordListController override

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -15,6 +15,9 @@ parameters:
 	excludePaths:
 		- ../../.Build
 		- ../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
+		# @todo Split the excludes into dedicated config files, after splitted PHPStan
+		# 		  configuration and baseline file have been introduced. Eventually keeping
+		- ../../Classes/Override/Core12/DeeplRecordListController.php
 
 	# @todo recheck rules.
 	inferPrivatePropertyTypeFromConstructor: true

--- a/Classes/Override/Core11/DeeplRecordListController.php
+++ b/Classes/Override/Core11/DeeplRecordListController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WebVision\WvDeepltranslate\Override;
+namespace WebVision\WvDeepltranslate\Override\Core11;
 
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -15,12 +15,13 @@ use TYPO3\CMS\Recordlist\Controller\RecordListController;
 use WebVision\WvDeepltranslate\Service\DeeplGlossaryService;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
-class DeeplRecordListController extends RecordListController
+final class DeeplRecordListController extends RecordListController
 {
     /**
      * @param string $requestUri
+     * @param mixed $_forwardCore12CombatAndUnused
      */
-    protected function languageSelector($requestUri): string
+    protected function languageSelector($requestUri, $_forwardCore12CombatAndUnused = null): string
     {
         if ($this->pageInfo['module'] === 'glossary') {
             return $this->buildGlossaryTranslationOptionDropdown($requestUri);

--- a/Classes/Override/Core12/DeeplRecordListController.php
+++ b/Classes/Override/Core12/DeeplRecordListController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Override\Core12;
+
+use TYPO3\CMS\Backend\Controller\RecordListController;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use WebVision\WvDeepltranslate\Service\DeeplGlossaryService;
+use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
+
+final class DeeplRecordListController extends RecordListController
+{
+    /**
+     * @param string $requestUri
+     */
+    protected function languageSelector(array $siteLanguages, string $requestUri): string
+    {
+        if ($this->pageInfo['module'] === 'glossary') {
+            return $this->buildGlossaryTranslationOptionDropdown($requestUri);
+        }
+        $originalOutput = parent::languageSelector($siteLanguages, $requestUri);
+
+        if ($originalOutput === '') {
+            return $originalOutput;
+        }
+
+        if (!DeeplBackendUtility::isDeeplApiKeySet()) {
+            return $originalOutput;
+        }
+
+        $options = DeeplBackendUtility::buildTranslateDropdown(
+            $siteLanguages,
+            $this->id,
+            $requestUri
+        );
+
+        if ($options == '') {
+            return $originalOutput;
+        }
+
+        return str_replace(
+            '<div class="col-auto">',
+            '<div class="col-auto row"><div class="col-sm-6">',
+            $originalOutput
+        )
+            . '<div class="col-sm-6">'
+            . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
+            . $options
+            . '</select>'
+            . '</div>'
+            . '</div>';
+    }
+
+    private function buildGlossaryTranslationOptionDropdown(string $requestUri): string
+    {
+        if (!$this->getBackendUserAuthentication()->check('tables_modify', 'pages')) {
+            return '';
+        }
+
+        $glossaryService = GeneralUtility::makeInstance(DeeplGlossaryService::class);
+        $possiblePairs = $glossaryService->getPossibleGlossaryLanguageConfig();
+        $site = GeneralUtility::makeInstance(SiteFinder::class)
+            ->getSiteByPageId($this->id);
+        $defaultLanguageIsoCode = $site->getDefaultLanguage()->getTwoLetterIsoCode();
+
+        $possibleGlossaryEntryLanguages = $possiblePairs[$defaultLanguageIsoCode] ?? [];
+
+        $availableTranslations = [];
+        foreach ($this->siteLanguages as $siteLanguage) {
+            if ($siteLanguage->getLanguageId() === 0) {
+                continue;
+            }
+            if (in_array($siteLanguage->getTwoLetterIsoCode(), $possibleGlossaryEntryLanguages)) {
+                $availableTranslations[$siteLanguage->getLanguageId()] = $siteLanguage->getTitle();
+            }
+        }
+
+        /**
+         * code copied from RecordListController
+         * @see RecordListController::languageSelector()
+         */
+        // Then, subtract the languages which are already on the page:
+        $localizationParentField = $GLOBALS['TCA']['pages']['ctrl']['transOrigPointerField'];
+        $languageField = $GLOBALS['TCA']['pages']['ctrl']['languageField'];
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, (int)$this->getBackendUserAuthentication()->workspace));
+        $statement = $queryBuilder->select('uid', $languageField)
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    $localizationParentField,
+                    $queryBuilder->createNamedParameter($this->id, Connection::PARAM_INT)
+                )
+            )
+            ->executeQuery();
+        while ($pageTranslation = $statement->fetchAssociative()) {
+            unset($availableTranslations[(int)$pageTranslation[$languageField]]);
+        }
+        // If any languages are left, make selector:
+        if (empty($availableTranslations)) {
+            return '';
+        }
+        $output = '<option value="">' . htmlspecialchars(
+            LocalizationUtility::translate(
+                'pages.glossary.translate',
+                'wv_deepltranslate'
+            )
+        ) . '</option>';
+
+        /**
+         * code copied from RecordListController
+         * @see RecordListController::languageSelector()
+         */
+        foreach ($availableTranslations as $languageUid => $languageTitle) {
+            // Build localize command URL to DataHandler (tce_db)
+            // which redirects to FormEngine (record_edit)
+            // which, when finished editing should return back to the current page (returnUrl)
+            $parameters = [
+                'justLocalized' => 'pages:' . $this->id . ':' . $languageUid,
+                'returnUrl' => $requestUri,
+            ];
+            $redirectUrl = (string)$this->uriBuilder->buildUriFromRoute('record_edit', $parameters);
+            $params = [];
+            $params['redirect'] = $redirectUrl;
+            $params['cmd']['pages'][$this->id]['localize'] = $languageUid;
+            $targetUrl = (string)$this->uriBuilder->buildUriFromRoute('tce_db', $params);
+            $output .= '<option value="' . htmlspecialchars($targetUrl) . '">' . htmlspecialchars($languageTitle) . '</option>';
+        }
+
+        return '<div class="col-auto">'
+            . '<select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">'
+            . $output
+            . '</select></div>';
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,8 @@
 defined('TYPO3') or die();
 
 (static function (): void {
+    $typo3version = new \TYPO3\CMS\Core\Information\Typo3Version();
+
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:wv_deepltranslate/Configuration/TsConfig/Page/pagetsconfig.tsconfig">'
     );
@@ -39,9 +41,15 @@ defined('TYPO3') or die();
         'className' => \WebVision\WvDeepltranslate\Override\DatabaseRecordList::class,
     ];
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Recordlist\Controller\RecordListController::class] = [
-        'className' => \WebVision\WvDeepltranslate\Override\DeeplRecordListController::class,
-    ];
+    if ($typo3version->getMajorVersion() >= 12) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Backend\\Controller\\RecordListController'] = [
+            'className' => 'WebVision\\WvDeepltranslate\\Override\\Core12\\DeeplRecordListController',
+        ];
+    } else {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Recordlist\\Controller\\RecordListController'] = [
+            'className' => 'WebVision\\WvDeepltranslate\\Override\\Core11\\DeeplRecordListController',
+        ];
+    }
 
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         //xclass CommandMapPostProcessingHook for translating contents within containers


### PR DESCRIPTION
The `RecordListController` is extended and replaced using XCLASS
technique.

With TYPO3 v12 we now have two things to tackle:

* The controller moved from `ext:record_list` to `ext:backend`
  providing a classmap alias as deprecation layer.
* Method signature for controller method `languageSelector()`
  changed leading to PHP fatal error due to method signature
  incompatibilty.

Even refactored to two controller implementation and using a
corresponding version switch for declaring the used class to
be xlassed, the method signature problem is present. However,
this can mitigated to add a unused second argument for the
TYPO3 v11 RecordListController override class, which is done.

Tasks:

* Rename `\WebVision\WvDeepltranslate\Override\DeeplRecordListController`
  to `\WebVision\WvDeepltranslate\Override\Core11\DeeplRecordListController`.

* Provide the working TYPO3 v12 implementation as
  `\WebVision\WvDeepltranslate\Override\Core12\DeeplRecordListController`.

* Use a unused second untyped argument for the v11 override to avoid
  PHP Fatal Error during compile time.

* Conditionally register xclass for `RecordListController` override in
  `ext_localconf.php`.

Resolves: web-vision/wv_deepltranslate-eap#1
Releases: main

- [x] Needs to be rebased after web-vision/wv_deepltranslate#254 has been merged.
