### PR TITLE
[BUGFIX] Guard `LocalizationUtility::translate` with `(string)` cast

### DIFF
--- a/Classes/Controller/GlossarySyncController.php
+++ b/Classes/Controller/GlossarySyncController.php
@@ -46,11 +46,11 @@ class GlossarySyncController
 
         $flashMessage = GeneralUtility::makeInstance(
             FlashMessage::class,
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'glossary.sync.message',
                 'wv_deepltranslate'
             ),
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'glossary.sync.title',
                 'wv_deepltranslate'
             ),

--- a/Classes/Controller/SettingsController.php
+++ b/Classes/Controller/SettingsController.php
@@ -104,8 +104,8 @@ class SettingsController extends ActionController
         }
 
         $this->addFlashMessage(
-            LocalizationUtility::translate('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:deprecated.deepl-be.body'),
-            LocalizationUtility::translate('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:deprecated.deepl-be.title'),
+            (string)LocalizationUtility::translate('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:deprecated.deepl-be.body'),
+            (string)LocalizationUtility::translate('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:deprecated.deepl-be.title'),
             $massagesType
         );
 
@@ -143,7 +143,7 @@ class SettingsController extends ActionController
         }
 
         $this->addFlashMessage(
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'settings_success',
                 'wv_deepltranslate'
             )

--- a/Classes/Hooks/ButtonBarHook.php
+++ b/Classes/Hooks/ButtonBarHook.php
@@ -42,7 +42,7 @@ class ButtonBarHook
                     ->check('tables_modify', 'tx_wvdeepltranslate_glossaryentry')
             ) {
                 $parameters = $this->buildParamsArrayForListView($page['uid']);
-                $title = LocalizationUtility::translate(
+                $title = (string)LocalizationUtility::translate(
                     'glossary.sync.button.all',
                     'wv_deepltranslate'
                 );

--- a/Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
+++ b/Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
@@ -54,11 +54,11 @@ class UpdatedGlossaryEntryTermHook
         $this->glossaryRepository->setGlossaryNotSyncOnPage($glossary['pid']);
 
         $flashMessage = new FlashMessage(
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'glossary.not-sync.message',
                 'wv_deepltranslate'
             ),
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'glossary.not-sync.title',
                 'wv_deepltranslate'
             ),

--- a/Classes/Override/DeeplRecordListController.php
+++ b/Classes/Override/DeeplRecordListController.php
@@ -110,7 +110,7 @@ class DeeplRecordListController extends RecordListController
             return '';
         }
         $output = '<option value="">' . htmlspecialchars(
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'pages.glossary.translate',
                 'wv_deepltranslate'
             )

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -148,7 +148,7 @@ class DeeplBackendUtility
         $params['cmd']['localization']['custom']['mode'] = 'deepl';
         $href = self::buildBackendRoute('tce_db', $params);
         $title =
-            LocalizationUtility::translate(
+            (string)LocalizationUtility::translate(
                 'backend.button.translate',
                 'wv_deepltranslate',
                 [
@@ -287,7 +287,7 @@ class DeeplBackendUtility
             if ($output !== '') {
                 $output = sprintf(
                     '<option value="">%s</option>%s',
-                    htmlspecialchars(LocalizationUtility::translate('backend.label', 'wv_deepltranslate')),
+                    htmlspecialchars((string)LocalizationUtility::translate('backend.label', 'wv_deepltranslate')),
                     $output
                 );
             }


### PR DESCRIPTION
The `LocalizationUtility::translate()` is used
in several places to translate something. The
method may return a string or null, where as
the used places usual expects to have a valid
string afterwards. For example, if the return
value is null and used to pass it to another
method like `htmlspecialchars()` this will
violates added argument types with PHP 8.0.

To avoid emitted PHP warnings call to this
method is guarded with a explicit `(string)`
type cast to mitigate this issue.

Releases: main, 3.0
