### PR TITLE
[TASK] Avoid instantiating PageRenderer in `ext_localconf.php`

### DIFF
--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Hooks;
+
+use TYPO3\CMS\Core\Page\PageRenderer;
+
+final class PageRendererHook
+{
+    /**
+     * Ensure backend javascript module is required and loaded.
+     *
+     * @param array<string, mixed> $params
+     */
+    public function renderPreProcess(array $params, PageRenderer $pageRenderer): void
+    {
+        if ($pageRenderer->getApplicationType() === 'BE') {
+            // @todo Validate and check if we need to use dedicated backend modules per core version or if a central
+            //       one is compatible enough.
+            $pageRenderer->loadRequireJsModule('TYPO3/CMS/WvDeepltranslate/Localization');
+        }
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -54,14 +54,11 @@ if (!defined('TYPO3_MODE')) {
         }
     }
 
-    if (
-        TYPO3_MODE === 'BE'
-        && \WebVision\WvDeepltranslate\Utility\DeeplBackendUtility::isDeeplApiKeySet()
-    ) {
-        // overriding localization.js
-        $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
-        $pageRenderer->loadRequireJsModule('TYPO3/CMS/WvDeepltranslate/Localization');
-    }
+    // We need to provide the global backend javascript module instead of calling page-renderer here directly - which
+    // cannot be done and checking the context (FE/BE) directly. Instantiating PageRenderer here directly would be
+    // emitted an exception as the cache configuration manager cannot be retrieved in this early stage.
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][1684661135]
+        = \WebVision\WvDeepltranslate\Hooks\PageRendererHook::class . '->renderPreProcess';
 
     //add caching for DeepL API-supported Languages
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['wvdeepltranslate']


### PR DESCRIPTION
Registering custom backend javascript modules have been
done historically by instantiating the PageRenderer in
the `ext_localconf.php` for `TYPO3_MODE === 'BE'`. That
was a valid way to do so.

The `TYPO3_MODE` constant has been deprecated and will
be removed in TYPO3 v12, which means that adding the
JS module could not be restricted to the backend context.

Furthermore, instantiating the PageRenderer with TYPO3
v12 in the `ext_localconf.php` file would emit an error
exception due to the fact that the page renderer needs
a cache. Instantiating the CacheManager in an early stage
is not possible which further disqualifies to add the
JavaScript module in the `ext_localconf.php`.

Generally there are multiple ways to mitigate this issue,
but the decision has been made to use an `PageRenderer`
hook directly. That has the major benefit of getting the
PageRenderer passed and no need to instantiate or inject
it in any way. We get the application context deliverd
for free with it, so no need to directly acces the global
request object. That makes this the best win-win solution.

We do not need the additionally and later features of the
`\TYPO3\CMS\Core\Page\Event\BeforeJavaScriptsRenderingEvent`
and thus not using it.

This paves the way further for TYPO3 v12 compatibility.

**NOTE:** This changes does not validates if the JS module
          itself is compatible with TYPO3 v12. This should
          be done in a dedicated patch when general support
          is in a stage this can be checked.

Resolves: #222
Related: #128
Releases: main
