### PR TITLE
[TASK] Replace deprecated `TYPO3_MODE` constant usage

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die();
-}
+defined('TYPO3') or die();
 
 (static function (): void {
     $ll = function (string $languageKey) {

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,7 +1,5 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die();
-}
+defined('TYPO3') or die();
 
 $GLOBALS['TCA']['tt_content']['columns']['subheader']['l10n_mode'] = 'prefixLangTitle';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die();
-}
+defined('TYPO3') or die();
 
 (static function (): void {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
+defined('TYPO3') or die();
 
 (function () {
     $iconProviderConfiguration = [


### PR DESCRIPTION
The `TYPO3_MODE` constant defined is deprecated
and removed with TYPO3 v12. It's recommended to
use the `TYPO3` constant for the known file
`defined() or die()` guard.

This change replaces the simply guards with the
new constant, which is already available in the
TYPO3 v11 version.

**NOTE:**   One usage in `ext_localconf.php` is
            not touched as this requires a more
            enhanced replacement. That has been
            provided with #258 already.

Resolves: #259
Related: #128
Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/66948
Releases: main
