### PR TITLE
[TASK] Mark test classes `final`

### DIFF
--- a/Tests/Functional/ClientTest.php
+++ b/Tests/Functional/ClientTest.php
@@ -15,7 +15,7 @@ use WebVision\WvDeepltranslate\Configuration;
 /**
  * @covers \WebVision\WvDeepltranslate\Client
  */
-class ClientTest extends FunctionalTestCase
+final class ClientTest extends FunctionalTestCase
 {
     use JsonAssertions;
 

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use WebVision\WvDeepltranslate\Configuration;
 
-class ConfigurationTest extends FunctionalTestCase
+final class ConfigurationTest extends FunctionalTestCase
 {
     /**
      * @var non-empty-string[]

--- a/Tests/Functional/Form/Items/SiteConfigSupportedLanguageItemsProcFuncTest.php
+++ b/Tests/Functional/Form/Items/SiteConfigSupportedLanguageItemsProcFuncTest.php
@@ -11,7 +11,7 @@ use WebVision\WvDeepltranslate\Form\Item\SiteConfigSupportedLanguageItemsProcFun
 /**
  * @covers \WebVision\WvDeepltranslate\Form\Item\SiteConfigSupportedLanguageItemsProcFunc
  */
-class SiteConfigSupportedLanguageItemsProcFuncTest extends FunctionalTestCase
+final class SiteConfigSupportedLanguageItemsProcFuncTest extends FunctionalTestCase
 {
     /**
      * @var non-empty-string[]

--- a/Tests/Functional/Hooks/TranslateHookTest.php
+++ b/Tests/Functional/Hooks/TranslateHookTest.php
@@ -19,7 +19,7 @@ use WebVision\WvDeepltranslate\Tests\Functional\Fixtures\Traits\SiteBasedTestTra
 /**
  * @covers \WebVision\WvDeepltranslate\Hooks\TranslateHook
  */
-class TranslateHookTest extends FunctionalTestCase
+final class TranslateHookTest extends FunctionalTestCase
 {
     use SiteBasedTestTrait;
     protected const LANGUAGE_PRESETS = [

--- a/Tests/Functional/Services/DeeplServiceTest.php
+++ b/Tests/Functional/Services/DeeplServiceTest.php
@@ -14,7 +14,7 @@ use WebVision\WvDeepltranslate\Service\DeeplService;
 /**
  * @covers \WebVision\WvDeepltranslate\Service\DeeplService
  */
-class DeeplServiceTest extends FunctionalTestCase
+final class DeeplServiceTest extends FunctionalTestCase
 {
     /**
      * @var non-empty-string[]

--- a/Tests/Functional/Services/LanguageServiceTest.php
+++ b/Tests/Functional/Services/LanguageServiceTest.php
@@ -12,7 +12,7 @@ use WebVision\WvDeepltranslate\Exception\LanguageRecordNotFoundException;
 use WebVision\WvDeepltranslate\Service\LanguageService;
 use WebVision\WvDeepltranslate\Tests\Functional\Fixtures\Traits\SiteBasedTestTrait;
 
-class LanguageServiceTest extends FunctionalTestCase
+final class LanguageServiceTest extends FunctionalTestCase
 {
     use SiteBasedTestTrait;
 

--- a/Tests/Functional/Updates/GlossaryUpgradeWizardTest.php
+++ b/Tests/Functional/Updates/GlossaryUpgradeWizardTest.php
@@ -14,7 +14,7 @@ use WebVision\WvDeepltranslate\Upgrades\GlossaryUpgradeWizard;
 /**
  * @covers \WebVision\WvDeepltranslate\Upgrades\GlossaryUpgradeWizard
  */
-class GlossaryUpgradeWizardTest extends FunctionalTestCase
+final class GlossaryUpgradeWizardTest extends FunctionalTestCase
 {
     /**
      * @var non-empty-string[]


### PR DESCRIPTION
It's recommend that test classes should not
extend from each other. This is not the case,
so mark all tests final.

Releases: main
