### PR TITLE
[TASK] Migrate documentation rendering to `runTests.sh`

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3'
 services:
   # This is the service name used when running ddev commands accepting the
   # --service flag.
@@ -545,6 +545,15 @@ services:
         php -v | grep '^PHP';
         .Build/bin/typoscript-lint --ansi --config=./Build/typoscript-lint/typoscript-lint.yml
       "
+
+  render_documentation:
+    platform: linux/amd64
+    image: ghcr.io/t3docs/render-documentation:develop
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:/PROJECT:ro
+      - ${ROOT_DIR}/Documentation-GENERATED-temp:/RESULT
+    command: makehtml
 
   phpstan:
     image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  t3docmake:
-    platform: linux/amd64
-    image: ghcr.io/t3docs/render-documentation:latest
-    command: makehtml
-    volumes:
-      - ./:/PROJECT:ro
-      - ./Documentation-GENERATED-temp:/RESULT


### PR DESCRIPTION
Having multiple execution points are not really
user friendly. Distributing config and docker
compose files is also not a really good idea.

This change now integrates the documentation
rendering container as `runTests.sh` task and
into the underlying `docker-compose.yaml`.

Furthermore, the `develop` tag is used as this
is the real latest rendering container provided
by the TYPO3 documentation team. This may change
at any point and can than be changed back. With
this, rendering warnings are solved due a bug
in the published `latest` container.

Thus removing the file in the project root
folder to clean that up a bit.

Resolves: https://github.com/web-vision/wv_deepltranslate/issues/256
Releases: main