### PR TITLE
[BUGFIX] Avoid undefined array key warning in `LocalizationController`

### DIFF
--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -67,7 +67,7 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
 
         $pageId     = (int)$params['pageId'];
         $languageId = (int)$params['languageId'];
-        $mode       = $params['mode'];
+        $mode       = $params['mode'] ?? '';
 
         /** @var TranslationConfigurationProvider $translationProvider */
         $translationProvider = GeneralUtility::makeInstance(TranslationConfigurationProvider::class);


### PR DESCRIPTION
> Core: Exception handler (WEB: BE): TYPO3\CMS\Core\Error\Exception, code #1476107295, file /private/typo3/sysext/core/Classes/Error/ErrorHandler.php, line 137: PHP Warning: Undefined array key "mode" in /private/typo3conf/ext/wv_deepltranslate/Classes/Override/LocalizationController.php line 77- Exception: PHP Warning: Undefined array key "mode" in /private/typo3conf/ext/wv_deepltranslate/Classes/Override/LocalizationController.php line 77, in file /private/typo3/sysext/core/Classes/Error/ErrorHandler.php:137