### PR TITLE
[BUGFIX] Determine glossary correct on current page

### DIFF
--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -343,8 +343,8 @@ class DeeplBackendUtility
         self::$currentPage = [];
         $request = $GLOBALS['TYPO3_REQUEST'];
         $queryParams = $request ? $request->getQueryParams() : [];
-        if (isset($queryParams['id'])) {
-            $currentId = (int)$queryParams['id'];
+        if (isset($queryParams['id']) || isset($queryParams['pageId'])) {
+            $currentId = (int)($queryParams['id'] ?? $queryParams['pageId']);
             return self::getPageRecord($currentId);
         }
         if (isset($queryParams['cmd'])) {


### PR DESCRIPTION
Until TYPO3 v10, the page ID in requests is given as `pageId` instead of
`id`. This bugfix respects the given request and detects correct page ID
in DeeplBackendUtility for determining glossary.

Backport to v4 not necessary, as since TYPO3 v11 the ID is given as `id`

closes #238 