### PR TITLE
[BUGFIX] Respect correct namespace for used `b13/container` class

### DIFF
--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -179,10 +179,16 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
         // s. EXT:containers Xclass B13\Container\Xclasses\LocalizationController
         if (
             \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')
-            && class_exists(\B13\Container\Xclasses\RecordLocalizeSummaryModifier::class)
         ) {
-            $recordLocalizeSummaryModifier = GeneralUtility::makeInstance(\B13\Container\Xclasses\RecordLocalizeSummaryModifier::class);
-            $payloadBody = $recordLocalizeSummaryModifier->rebuildPayload($payloadBody);
+            if (class_exists(\B13\Container\Service\RecordLocalizeSummaryModifier::class)) {
+                // since b13/container 2.1.0
+                $recordLocalizeSummaryModifier = GeneralUtility::makeInstance(\B13\Container\Service\RecordLocalizeSummaryModifier::class);
+                $payloadBody = $recordLocalizeSummaryModifier->rebuildPayload($payloadBody);
+            } elseif (class_exists(\B13\Container\Xclasses\RecordLocalizeSummaryModifier::class)) {
+                // before b13/container 2.1.0
+                $recordLocalizeSummaryModifier = GeneralUtility::makeInstance(\B13\Container\Xclasses\RecordLocalizeSummaryModifier::class);
+                $payloadBody = $recordLocalizeSummaryModifier->rebuildPayload($payloadBody);
+            }
         }
 
         return (new JsonResponse())->setPayload($payloadBody);


### PR DESCRIPTION
`b13/container` moved a class with v2.1.0 to another
namespace. We instantiated and called that class to
re-run code in xclassed class which both extensions
needs to xclass and combine both tasks.

This change now checks for both possible classes and
use the correct ones. Using kind of package or composer
information is not reliable enough and more complex
than the chosen `class_exist` check.

The newer namespace is checked first, in case the
container extensions adds a class_alias for the old
one. Directly using the new class if existing is the
better way.

See: https://github.com/b13/container/commit/5d57961165efd2828fafcf291c5e19b1400baef1#diff-1b5dddc7fdc72ce709fe89a91a8873332a6f6755209043cb81c3b116ee70f738

Resolves: #276
