### PR TITLE
[BUGFIX] Trim glossary terms to prevent exception from DeepL API

### DIFF
--- a/Configuration/TCA/tx_wvdeepltranslate_glossaryentry.php
+++ b/Configuration/TCA/tx_wvdeepltranslate_glossaryentry.php
@@ -86,7 +86,7 @@ return [
             'l10n_mode' => '',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'eval' => 'trim,required',
             ],
         ],
     ],


### PR DESCRIPTION
The DeepL API doesn't allow trailing whitespaces for glossary terms and returns a 400 Bad Request during sync.