### PR TITLE
[DOCS] Add note about table configuration for custom records

### DIFF
--- a/Documentation/Editor/Usage/Index.rst
+++ b/Documentation/Editor/Usage/Index.rst
@@ -54,3 +54,7 @@ translation.
 
 .. figure:: /Images/Editor/translation-button-news.png
     :alt: Translation button for tx_news, one language not available in DeepL
+
+.. note::
+   Fields of custom extensions need to be properly
+   :ref:`configured <tableConfiguration>` to enable translation.


### PR DESCRIPTION
Just a small hint in the docs about the table configuration. Just in case an editors wonders, why translation doesn't work for certain TCA fields.