### PR TITLE
[BUGFIX] Fix locallangXMLOverride

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -71,7 +71,7 @@ if (!defined('TYPO3_MODE')) {
         );
     }
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['/typo3/sysext/backend/Resources/Private/Language/locallang_layout.xlf'] = 'EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:backend/Resources/Private/Language/locallang_layout.xlf'][] = 'EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf';
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('tx_wvdeepltranslate_domain_model_glossaries', 'EXT:wv_deepltranslate/Resources/Private/Language/locallang_csh_tx_wvdeepltranslate_domain_model_glossaries.xlf');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_wvdeepltranslate_domain_model_glossaries');


### PR DESCRIPTION
See https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Localization/ManagingTranslations.html?highlight=locallangxmloverride

This fixes the "undefined" labels situation in TYPO3 11:

![Screenshot from 2023-09-22 15-56-56](https://github.com/web-vision/wv_deepltranslate/assets/1405149/4add1246-d9c4-43f4-8e2e-fe14434ecbf0)