### PR TITLE
[BUGFIX] LocalizationController not loaded when EXT:container is installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,9 @@
 		"typo3/cms-workspaces": "^9.5 || ^10.4 || ^11.5",
 		"typo3/coding-standards": "^0.5"
 	},
+	"suggest": {
+		"b13/container": "Just to be loaded after EXT:container"
+	},
 	"autoload": {
 		"psr-4": {
 			"WebVision\\WvDeepltranslate\\": "Classes"


### PR DESCRIPTION
This tweaks the order in which extensions are being loaded. To let EXT:wv_deepltranslate have the upper hand when it comes to xclassing LocalizationController it's necessary to define `b13/container` as a kinda "dependency" of this extension.

Without it this happens:
![image](https://github.com/web-vision/wv_deepltranslate/assets/1405149/f2af5d70-5379-47eb-840e-945dc317bed9)
