### PR TITLE
Fix upgrade wizard

### DIFF
--- a/Classes/Upgrades/GlossaryUpgradeWizard.php
+++ b/Classes/Upgrades/GlossaryUpgradeWizard.php
@@ -65,10 +65,21 @@ class GlossaryUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
 
         $updateGlossary = [];
         foreach ($result as $item) {
-            unset($item['description']);
-            unset($item['starttime']);
-            unset($item['endtime']);
-            $updateGlossary[] = $item;
+            $updateGlossary[] = [
+                'uid' => $item['uid'],
+                'pid' => $item['pid'],
+                'tstamp' => $item['tstamp'],
+                'crdate' => $item['crdate'],
+                'cruser_id' => $item['cruser_id'],
+                'deleted' => $item['deleted'],
+                'hidden' => $item['hidden'],
+                'sys_language_uid' => $item['sys_language_uid'],
+                'l10n_parent' => $item['l10n_parent'],
+                'l10n_source' => $item['l10n_source'],
+                'l10n_state' => $item['l10n_state'],
+                'l10n_diffsource' => $item['l10n_diffsource'],
+                'term' => $item['term'],
+            ];
         }
 
         $insert = GeneralUtility::makeInstance(ConnectionPool::class)


### PR DESCRIPTION
Avoid SQL errors in the Upgrade Wizard from v2 to v3. Errors like:

```
In AbstractMySQLDriver.php line 79:
                                                                                                                                              
  An exception occurred while executing 'INSERT INTO `tx_wvdeepltranslate_glossaryentry` (`uid`, `pid`, `tstamp`, `crdate`, `cruser_id`, `de  
  leted`, `hidden`, `sorting`, `sys_language_uid`, `l10n_parent`, `l10n_source`, `l10n_state`, `l10n_diffsource`, `t3ver_oid`, `t3ver_wsid`,  
   `t3ver_state`, `t3ver_stage`, `t3ver_count`, `t3ver_tstamp`, `t3ver_move_id`, `term`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?  
  , ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,   
  ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,  
   ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?,  
   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params  
   [1, 752, 1670403261, 1670403261, 8, 0, 0, 256, 0, 0, 0, null, "", 0, 0, 0, 0, 0, 0, 0, "Apfel", 2, 752, 1670511746, 1670403281, 8, 0, 0,   
  512, 1, 1, 1, "{\"starttime\":\"parent\",\"endtime\":\"parent\"}", "{\"sys_language_uid\":0,\"l10n_parent\":0,\"hidden\":0,\"term\":\"Apfe  
  l\",\"description\":\"\"}", 0, 0, 0, 0, 0, 0, 0, "appledapple", 3, 752, 1670509754, 1670420348, 8, 1, 0, 128, 0, 0, 0, null, "", 0, 0, 0,   
  0, 0, 1670420457, 0, "Farbe", 5, 752, 1670509749, 1670420388, 8, 1, 0, 192, 1, 3, 3, "{\"starttime\":\"parent\",\"endtime\":\"parent\"}",   
  "{\"sys_language_uid\":0,\"l10n_parent\":0,\"hidden\":0,\"term\":\"Farbe\",\"description\":\"\",\"starttime\":0,\"endtime\":0}", 0, 0, 0,   
  0, 0, 1670420457, 0, "colour", 7, 752, 1670514255, 1670514255, 8, 0, 0, 128, 0, 0, 0, null, "", 0, 0, 0, 0, 0, 0, 0, "Alter Verwalter", 8,  
   752, 1670514432, 1670514293, 8, 0, 0, 192, 1, 7, 7, "{\"starttime\":\"parent\",\"endtime\":\"parent\"}", "{\"sys_language_uid\":0,\"l10n_  
  parent\":0,\"hidden\":0,\"term\":\"Alter Verwalter\",\"description\":\"\"}", 0, 0, 0, 0, 0, 0, 0, "old bailiff", 9, 752, 1670515336, 16705  
  15336, 8, 0, 0, 64, 0, 0, 0, null, "", 0, 0, 0, 0, 0, 0, 0, "Farbe", 10, 752, 1670515363, 1670515351, 8, 0, 0, 96, 1, 9, 9, "{\"starttime\  
  ":\"parent\",\"endtime\":\"parent\"}", "{\"sys_language_uid\":0,\"l10n_parent\":0,\"hidden\":0,\"term\":\"Farbe\",\"description\":\"\"}",   
  0, 0, 0, 0, 0, 0, 0, "colour", 11, 752, 1670517872, 1670517868, 8, 0, 0, 32, 0, 0, 0, null, "{\"sys_language_uid\":null,\"hidden\":null,\"  
  term\":null,\"description\":null,\"starttime\":null,\"endtime\":null}", 0, 0, 0, 0, 0, 0, 0, "Test"]:                                       
                                                                                                                                              
  Unknown column 'sorting' in 'field list'                                                                                                    
```

And plenty of other fields that are present in `tx_wvdeepltranslate_domain_model_glossaries` but not present in `tx_wvdeepltranslate_glossaryentry`.