### PR TITLE
[BUGFIX] Use TYPO3 configured proxy for deepl client

### DIFF
--- a/Classes/AbstractClient.php
+++ b/Classes/AbstractClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WebVision\WvDeepltranslate;
 
 use DeepL\Translator;
+use DeepL\TranslatorOptions;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvDeepltranslate\Exception\ApiKeyNotSetException;
@@ -43,7 +44,16 @@ abstract class AbstractClient implements ClientInterface
             throw new ApiKeyNotSetException('The api key ist not set', 1708081233823);
         }
 
-        $this->translator = GeneralUtility::makeInstance(Translator::class, $this->configuration->getApiKey());
+        $options = [];
+        if (
+            isset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'])
+            && $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'] !== ''
+            && GeneralUtility::isValidUrl($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'])
+        ) {
+            $options[TranslatorOptions::PROXY] = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'];
+        }
+
+        $this->translator = new Translator($this->configuration->getApiKey(), $options);
 
         return $this->translator;
     }


### PR DESCRIPTION
When converting the client, the proxy configuration via TYPO3 was no longer taken into account. This will be made up for with this change.

resolve #330 