### PR TITLE
[BUGFIX] Mitigate unrelated page traversal for glossary lookup

### DIFF
--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -236,6 +236,11 @@ parameters:
 			path: ../../../Classes/Utility/HtmlUtility.php
 
 		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/AbstractDeepLTestCase.php
+
+		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Fixtures\\\\Frontend\\\\PhpError\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Fixtures/Frontend/PhpError.php

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -236,6 +236,11 @@ parameters:
 			path: ../../../Classes/Utility/HtmlUtility.php
 
 		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/AbstractDeepLTestCase.php
+
+		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Fixtures\\\\Frontend\\\\PhpError\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Fixtures/Frontend/PhpError.php


### PR DESCRIPTION
Based on the concept the matching glossaries for the current site root tree should be used for translation process. Glossaries are managed on default pages with the `glossaries` module attached, thus are free to be defined within the page tree structure. Using a page traversal approach from the detected site root becomes really costly as it traverse the full page tree beneath the matched site root, thus becoming quickly quite costly.

Albeit not the best approach, retrieving pages with the module attached and using the SiteFinder and therefore the rootline to sort out module pages not included for the site root reduces the traversed and retrieved pages white a lot.

Note: With dropping TYPO3 v12 support it would be possible to use handcrafted common table expressions to further optimize that lookup and with TYPO3 v13 at least TYPO3 Core internal API may be available.

This change modifies the glossary id lookup method to exchange the pagetraversal approach with a flat record list rootline check approach as a first, quick and non breaking improvement. Instances not using the glossary feature avoids the recursive traversal at all with this implementation.

Resolve #334 
