### PR TITLE
[TASK] Avoid implicitly nullable class method parameter

### DIFF
--- a/Tests/Functional/Fixtures/Traits/SiteBasedTestTrait.php
+++ b/Tests/Functional/Fixtures/Traits/SiteBasedTestTrait.php
@@ -119,7 +119,7 @@ trait SiteBasedTestTrait
         string $identifier,
         string $base,
         array $fallbackIdentifiers = [],
-        string $fallbackType = null
+        ?string $fallbackType = null
     ): array {
         $preset = $this->resolveLanguagePreset($identifier);
 


### PR DESCRIPTION
With PHP 8.4 marking method parameter implicitly nullable
is deprecated and will emit a `E_DEPRECATED` warning. One
recommended way to resolve this, is making it explicitly
nullable using the `?` nullable operator or adding a null
type to an union type definition. [[1]](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

This prepares the way towards PHP 8.4 compatibility.

* [[1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

Resolves: #344
