### PR TITLE
[TASK] Streamline tooling

### DIFF
--- a/Build/php-cs-fixer/php-cs-rules.php
+++ b/Build/php-cs-fixer/php-cs-rules.php
@@ -59,6 +59,10 @@ return (new PhpCsFixer\Config())
         'phpdoc_trim' => true,
         'no_superfluous_elseif' => true,
         'no_useless_else' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
         'return_type_declaration' => ['space_before' => 'none'],


### PR DESCRIPTION
- **[TASK] Streamline `Build/Scripts/runTests.sh`**
  This change adopts the latest envolments from the TYPO3
  Core implementation of `Build/Scripts/runTests.sh`.
  
  This change ...
  
  * now registers SIGINT trap only when not in known
    CI environments.
  * updates supported MySQL Server versions for `-i`.
  * adds `PHP 8.4` as allowed PHP version.
  * replaced container image prefixes with full image
    names.
  

- **[TASK] Ensure coding-style for nullable type declarations**
  This change modifies the `php-cs-fixer` ruleset and
  activate two rules related to nullable types.
  
  Following options are added:
  
    'nullable_type_declaration' => [
      'syntax' => 'question_mark',
    ],
    'nullable_type_declaration_for_default_null_value' => true,
  
  `nullable_type_declaration` ensures to use `?<type>` declaration
  instead of union type `<type>|null` as a convention for properties,
  method and return types. For already union types the nullable is
  added as additional null union type `ObjectOne|ObjectInterface|null`.
  
  `nullable_type_declaration_for_default_null_value` ensures
  to use nullable type declarations to mitigate implicitly
  nullable method arguments [1] which has been already fixed
  with a series of dedicated changes.
  
  Note that the same work has already be done throughout the TYPO3
  Core with a series of patches to prepare towards this and finally
  enabling the same rules for the TYPO3 Core Ruleset.
  
  Used command(s):
  
    Build/Scripts/runTests.sh -s cgl
  
  [1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  