### PR TITLE
Improve usage readability

### DIFF
--- a/Classes/Event/Listener/UsageToolBarEventListener.php
+++ b/Classes/Event/Listener/UsageToolBarEventListener.php
@@ -40,13 +40,17 @@ class UsageToolBarEventListener implements LoggerAwareInterface
             }
             return;
         }
+
+        $title = $this->getLanguageService()->sL(
+            'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar-label'
+        );
+        $message = $this->getLanguageService()->sL(
+            'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar.message'
+        );
+
         $systemInformation->getToolbarItem()->addSystemInformation(
-            $this->getLanguageService()->sL('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar-label'),
-            sprintf(
-                '%d / %d',
-                $usage->character->count,
-                $usage->character->limit
-            ),
+            $title,
+            sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
             'actions-localize-deepl',
         );
     }
@@ -54,5 +58,16 @@ class UsageToolBarEventListener implements LoggerAwareInterface
     private function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
+    }
+
+    /**
+     * Make large API limits easier to read
+     *
+     * @param int $number Any large integer - 5000000
+     * @return string Formated, better readable string variant of the integer - 5.000.000
+     */
+    private function formatNumber(int $number): string
+    {
+        return number_format($number, 0, ',', '.');
     }
 }

--- a/Classes/Event/Listener/UsageToolBarEventListener.php
+++ b/Classes/Event/Listener/UsageToolBarEventListener.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Event\Listener;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
+use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use WebVision\WvDeepltranslate\Exception\ApiKeyNotSetException;
 use WebVision\WvDeepltranslate\Service\UsageService;
@@ -52,6 +53,7 @@ class UsageToolBarEventListener implements LoggerAwareInterface
             $title,
             sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
             'actions-localize-deepl',
+            InformationStatus::STATUS_NOTICE,
         );
     }
 

--- a/Classes/Hooks/UsageProcessAfterFinishHook.php
+++ b/Classes/Hooks/UsageProcessAfterFinishHook.php
@@ -39,7 +39,10 @@ class UsageProcessAfterFinishHook
             return;
         }
 
-        $label = $this->getLanguageService()->sL(
+        $title = $this->getLanguageService()->sL(
+            'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.flashmassage.title'
+        );
+        $message = $this->getLanguageService()->sL(
             'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.flashmassage.limit.description'
         );
 
@@ -53,8 +56,8 @@ class UsageProcessAfterFinishHook
 
         $flashMessage = GeneralUtility::makeInstance(
             FlashMessage::class,
-            sprintf($label, $usage->character->count, $usage->character->limit),
-            'Deepl Usage',
+            sprintf($message, $usage->character->count, $usage->character->limit),
+            $title,
             $severity,
             true
         );

--- a/Classes/Hooks/UsageProcessAfterFinishHook.php
+++ b/Classes/Hooks/UsageProcessAfterFinishHook.php
@@ -49,9 +49,9 @@ class UsageProcessAfterFinishHook
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $notificationQueue = $flashMessageService->getMessageQueueByIdentifier();
 
-        $severity = -1;  // Info
+        $severity = FlashMessage::INFO;
         if ($this->usageService->isTranslateLimitExceeded()) {
-            $severity = 1;  // Warning
+            $severity = FlashMessage::WARNING;
         }
 
         $flashMessage = GeneralUtility::makeInstance(

--- a/Classes/Hooks/UsageProcessAfterFinishHook.php
+++ b/Classes/Hooks/UsageProcessAfterFinishHook.php
@@ -56,7 +56,7 @@ class UsageProcessAfterFinishHook
 
         $flashMessage = GeneralUtility::makeInstance(
             FlashMessage::class,
-            sprintf($message, $usage->character->count, $usage->character->limit),
+            sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
             $title,
             $severity,
             true
@@ -68,5 +68,10 @@ class UsageProcessAfterFinishHook
     private function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
+    }
+
+    private function formatNumber(int $number): string
+    {
+        return number_format($number, 0, ',', '.');
     }
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -199,8 +199,12 @@
 			</trans-unit>
 
 			<trans-unit id="usages.toolbar-label">
-				<source>DeepL Translate Limit</source>
+				<source>DeepL Translate Quota</source>
 				<target>DeepL Übersetzung Limit</target>
+			</trans-unit>
+			<trans-unit id="usages.toolbar.message">
+				<source>%s / %s</source>
+				<target>%s / %s</target>
 			</trans-unit>
 			<trans-unit id="usages.toolbar-information">
 				<source>Information not available</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -206,6 +206,14 @@
 				<source>Information not available</source>
 				<target>Information nicht verfügbar</target>
 			</trans-unit>
+			<trans-unit id="usages.flashmassage.title">
+				<source>DeepL usage and quota</source>
+				<target>DeepL Nutzung und Limits</target>
+			</trans-unit>
+			<trans-unit id="usages.flashmassage.limit.description">
+				<source>DeepL translations for current billing period: %s of %s characters</source>
+				<target>DeepL Übersetzungen für den aktuellen Abrechnungszeitraum: %s von %s Zeichen</target>
+			</trans-unit>
 
 			<!-- Widget -->
 			<trans-unit id="widgets.deepltranslate.widget.useswidget.title">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -174,7 +174,10 @@
 			</trans-unit>
 
 			<trans-unit id="usages.toolbar-label">
-				<source>DeepL Translate Limit</source>
+				<source>DeepL Translate Quota</source>
+			</trans-unit>
+			<trans-unit id="usages.toolbar.message">
+				<source>%s / %s</source>
 			</trans-unit>
 			<trans-unit id="usages.toolbar-information">
 				<source>Information not available</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -180,7 +180,7 @@
 				<source>Information not available</source>
 			</trans-unit>
 			<trans-unit id="usages.flashmassage.title">
-				<source>DeepL Translate </source>
+				<source>DeepL usage and quota</source>
 			</trans-unit>
 			<trans-unit id="usages.flashmassage.limit.description">
 				<source>DeepL Translate Limit %s / %s</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -183,7 +183,7 @@
 				<source>DeepL usage and quota</source>
 			</trans-unit>
 			<trans-unit id="usages.flashmassage.limit.description">
-				<source>DeepL Translate Limit %s / %s</source>
+				<source>DeepL translations for current billing period: %s of %s characters</source>
 			</trans-unit>
 
 			<!-- Translation Access | be_groups -->

--- a/Resources/Public/Icons/actions-localize-deepl.svg
+++ b/Resources/Public/Icons/actions-localize-deepl.svg
@@ -1,18 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;}
-	.st1{fill:#000000;}
-</style>
-    <rect id="canvas_background" x="0.5" y="7" class="st0" width="16" height="16"/>
-    <g id="g4185">
-	<g id="g4211">
-		<path id="path4213" class="st1" d="M10,8.2c-0.5,0-1-0.4-1-1C9,7.2,9,7.1,9,7L6.7,5.7C6.5,5.8,6.3,5.9,6,5.9c-0.5,0-1-0.4-1-1
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <g class="icon-color">
+        <path id="path4213" class="st1" d="M10,8.2c-0.5,0-1-0.4-1-1C9,7.2,9,7.1,9,7L6.7,5.7C6.5,5.8,6.3,5.9,6,5.9c-0.5,0-1-0.4-1-1
 			s0.4-1,1-1s1,0.5,1,1C7,5,7,5,7,5.1l2.3,1.4C9.5,6.3,9.7,6.2,10,6.2c0.5,0,1,0.4,1,1S10.5,8.2,10,8.2 M7,9.5c0,0.5-0.4,1-1,1
 			s-1-0.4-1-1s0.5-1,1-1c0.2,0,0.5,0.1,0.6,0.2l1.7-1C8.4,8,8.5,8.2,8.7,8.3L7,9.3C7,9.4,7,9.4,7,9.5 M12.9,3.5L8.3,0.8
 			c-0.3-0.2-0.7-0.2-1,0L2.6,3.5C2.2,3.7,2,4,2,4.4l0,5.4c0,0.4,0.2,0.7,0.5,0.9l8,4.7l0-3.3l2.3-1.3c0.3-0.2,0.5-0.5,0.5-0.9l0-5.4
 			C13.4,4.1,13.2,3.7,12.9,3.5"/>
-	</g>
-</g>
+    </g>
 </svg>


### PR DESCRIPTION
Make usage messages more readable (like “48.476 of 5.000.000” instead of “48476 / 5000000”).

Also adapt the action icon SVG similar to existing action icons of the TYPO3 core (these dont set fixed colors in order to let them change as needed in the context). Right now the DeepL icon is the only one in the system information bar which is black, this PR will fix this.

Before
![Bildschirmfoto vom 2024-09-06 16-58-53](https://github.com/user-attachments/assets/ffdf2b58-011a-48ff-92e1-c6705eff6c1b)

After
![Bildschirmfoto vom 2024-09-06 21-28-28](https://github.com/user-attachments/assets/181dc7a8-9da1-4cf9-bb91-545ed7438a39)
