### PR TITLE
Usage treshold & severity levels

### DIFF
--- a/Classes/Event/Listener/UsageToolBarEventListener.php
+++ b/Classes/Event/Listener/UsageToolBarEventListener.php
@@ -7,7 +7,6 @@ namespace WebVision\WvDeepltranslate\Event\Listener;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
-use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use WebVision\WvDeepltranslate\Exception\ApiKeyNotSetException;
 use WebVision\WvDeepltranslate\Service\UsageService;
@@ -49,11 +48,15 @@ class UsageToolBarEventListener implements LoggerAwareInterface
             'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar.message'
         );
 
-        $severity = $this->determineSeverity($usage->character->count, $usage->character->limit);
+        $severity = $this->usageService->determineSeverityForSystemInformation($usage->character->count, $usage->character->limit);
 
         $systemInformation->getToolbarItem()->addSystemInformation(
             $title,
-            sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
+            sprintf(
+                $message,
+                $this->usageService->formatNumber($usage->character->count),
+                $this->usageService->formatNumber($usage->character->limit)
+            ),
             'actions-localize-deepl',
             $severity
         );
@@ -62,39 +65,5 @@ class UsageToolBarEventListener implements LoggerAwareInterface
     private function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
-    }
-
-    /**
-     * Make large API limits easier to read
-     *
-     * @param int $number Any large integer - 5000000
-     * @return string Formated, better readable string variant of the integer - 5.000.000
-     */
-    private function formatNumber(int $number): string
-    {
-        return number_format($number, 0, ',', '.');
-    }
-
-
-    /**
-     * Calculate the message severity based on the quota usage rate
-     *
-     * @param int $characterCount Already translated characters in the current billing period
-     * @param int $characterLimit Total character limit in the current billing period
-     * @return string Severity level
-     */
-    private function determineSeverity(int $characterCount, int $characterLimit): string
-    {
-        $quotaUtilization = ($characterCount / $characterLimit) * 100;
-        if ($quotaUtilization >= 100) {
-            return InformationStatus::STATUS_ERROR;
-        }
-        if ($quotaUtilization >= 98) {
-            return InformationStatus::STATUS_WARNING;
-        }
-        if ($quotaUtilization >= 90) {
-            return InformationStatus::STATUS_INFO;
-        }
-        return InformationStatus::STATUS_NOTICE;
     }
 }

--- a/Classes/Event/Listener/UsageToolBarEventListener.php
+++ b/Classes/Event/Listener/UsageToolBarEventListener.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Event\Listener;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
+use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use WebVision\WvDeepltranslate\Exception\ApiKeyNotSetException;
 use WebVision\WvDeepltranslate\Service\UsageService;
@@ -40,19 +41,60 @@ class UsageToolBarEventListener implements LoggerAwareInterface
             }
             return;
         }
+
+        $title = $this->getLanguageService()->sL(
+            'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar-label'
+        );
+        $message = $this->getLanguageService()->sL(
+            'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar.message'
+        );
+
+        $severity = $this->determineSeverity($usage->character->count, $usage->character->limit);
+
         $systemInformation->getToolbarItem()->addSystemInformation(
-            $this->getLanguageService()->sL('LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.toolbar-label'),
-            sprintf(
-                '%d / %d',
-                $usage->character->count,
-                $usage->character->limit
-            ),
+            $title,
+            sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
             'actions-localize-deepl',
+            $severity
         );
     }
 
     private function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
+    }
+
+    /**
+     * Make large API limits easier to read
+     *
+     * @param int $number Any large integer - 5000000
+     * @return string Formated, better readable string variant of the integer - 5.000.000
+     */
+    private function formatNumber(int $number): string
+    {
+        return number_format($number, 0, ',', '.');
+    }
+
+
+    /**
+     * Calculate the message severity based on the quota usage rate
+     *
+     * @param int $characterCount Already translated characters in the current billing period
+     * @param int $characterLimit Total character limit in the current billing period
+     * @return string Severity level
+     */
+    private function determineSeverity(int $characterCount, int $characterLimit): string
+    {
+        $quotaUtilization = ($characterCount / $characterLimit) * 100;
+        if ($quotaUtilization >= 100) {
+            return InformationStatus::STATUS_ERROR;
+        }
+        if ($quotaUtilization >= 98) {
+            return InformationStatus::STATUS_WARNING;
+        }
+        if ($quotaUtilization >= 90) {
+            return InformationStatus::STATUS_INFO;
+        }
+        return InformationStatus::STATUS_NOTICE;
     }
 }

--- a/Classes/Hooks/UsageProcessAfterFinishHook.php
+++ b/Classes/Hooks/UsageProcessAfterFinishHook.php
@@ -46,7 +46,7 @@ class UsageProcessAfterFinishHook
             'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:usages.flashmassage.limit.description'
         );
 
-        $severity = $this->determineSeverity($usage->character->count, $usage->character->limit);
+        $severity = $this->usageService->determineSeverity($usage->character->count, $usage->character->limit);
         // Reduce noise - Don't bother editors with low quota usage messages
         if ($severity === FlashMessage::NOTICE) {
             return;
@@ -57,7 +57,11 @@ class UsageProcessAfterFinishHook
 
         $flashMessage = GeneralUtility::makeInstance(
             FlashMessage::class,
-            sprintf($message, $this->formatNumber($usage->character->count), $this->formatNumber($usage->character->limit)),
+            sprintf(
+                $message,
+                $this->usageService->formatNumber($usage->character->count) ?: $usage->character->count,
+                $this->usageService->formatNumber($usage->character->limit)
+            ) ?: $usage->character->limit,
             $title,
             $severity,
             true
@@ -69,38 +73,5 @@ class UsageProcessAfterFinishHook
     private function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
-    }
-
-    /**
-     * Make large API limits easier to read
-     *
-     * @param int $number Any large integer - 5000000
-     * @return string Formated, better readable string variant of the integer - 5.000.000
-     */
-    private function formatNumber(int $number): string
-    {
-        return number_format($number, 0, ',', '.');
-    }
-
-    /**
-     * Calculate the message severity based on the quota usage rate
-     *
-     * @param int $characterCount Already translated characters in the current billing period
-     * @param int $characterLimit Total character limit in the current billing period
-     * @return int Severity level
-     */
-    private function determineSeverity(int $characterCount, int $characterLimit): int
-    {
-        $quotaUtilization = ($characterCount / $characterLimit) * 100;
-        if ($quotaUtilization >= 100) {
-            return FlashMessage::ERROR;
-        }
-        if ($quotaUtilization >= 98) {
-            return FlashMessage::WARNING;
-        }
-        if ($quotaUtilization >= 90) {
-            return FlashMessage::INFO;
-        }
-        return FlashMessage::NOTICE;
     }
 }

--- a/Classes/Service/UsageService.php
+++ b/Classes/Service/UsageService.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace WebVision\WvDeepltranslate\Service;
 
 use DeepL\Usage;
+use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
 use WebVision\WvDeepltranslate\ClientInterface;
 
 final class UsageService implements UsageServiceInterface
@@ -46,5 +50,77 @@ final class UsageService implements UsageServiceInterface
             return false;
         }
         return $usage->character->count >= $usage->character->limit;
+    }
+
+    /**
+     * Make large API limits easier to read
+     *
+     * @param int $number Any large integer - 5000000
+     * @return string|false Formated, better readable string variant of the integer - 5.000.000
+     */
+    public function formatNumber(int $number)
+    {
+        // @todo typo3/cms-core:>=12 remove polyfill switch, as php-intl is
+        //       then a hard requirement and the polyfill is not needed
+        if ((new Typo3Version())->getMajorVersion() <= 12 && !extension_loaded('intl')) {
+            if (!class_exists(\NumberFormatter::class)) {
+                return number_format($number);
+            }
+            // TYPO3 v11 has a Symfony Polyfill, but this ony allows
+            // locale en or null, so we call with default parameter.
+            $numberFormatter = new \NumberFormatter('en', \NumberFormatter::DECIMAL);
+        } else {
+            $language = 'en';
+            if ($this->getBackendUser() !== null) {
+                $uc = $this->getBackendUser()->uc;
+                if (is_array($uc) && array_key_exists('lang', $uc)) {
+                    $language = $uc['lang'];
+                }
+            }
+            $numberFormatter = new \NumberFormatter($language, \NumberFormatter::DECIMAL);
+        }
+        return $numberFormatter->format($number);
+    }
+
+    /**
+     * Calculate the message severity based on the quota usage rate
+     *
+     * @param int $characterCount Already translated characters in the current billing period
+     * @param int $characterLimit Total character limit in the current billing period
+     * @return int Severity level
+     */
+    public function determineSeverity(int $characterCount, int $characterLimit): int
+    {
+        $quotaUtilization = ($characterCount / $characterLimit) * 100;
+        if ($quotaUtilization >= 100) {
+            return FlashMessage::ERROR;
+        }
+        if ($quotaUtilization >= 98) {
+            return FlashMessage::WARNING;
+        }
+        if ($quotaUtilization >= 90) {
+            return FlashMessage::INFO;
+        }
+        return FlashMessage::NOTICE;
+    }
+
+    public function determineSeverityForSystemInformation(int $characterCount, int $characterLimit): string
+    {
+        $quotaUtilization = ($characterCount / $characterLimit) * 100;
+        if ($quotaUtilization >= 100) {
+            return InformationStatus::STATUS_ERROR;
+        }
+        if ($quotaUtilization >= 98) {
+            return InformationStatus::STATUS_WARNING;
+        }
+        if ($quotaUtilization >= 90) {
+            return InformationStatus::STATUS_INFO;
+        }
+        return InformationStatus::STATUS_NOTICE;
+    }
+
+    private function getBackendUser(): ?BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'] ?? null;
     }
 }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -174,7 +174,7 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
                 'title' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.title',
                 'description' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.description',
                 'iconIdentifier' => 'content-widget-list',
-                'height' => 'medium',
+                'height' => 'small',
                 'width' => 'small',
             ])
         ;

--- a/Resources/Private/Backend/Templates/Widget/UsageWidget.html
+++ b/Resources/Private/Backend/Templates/Widget/UsageWidget.html
@@ -8,14 +8,23 @@
     <f:for as="item" each="{usages}" >
         <div class="mb-3">
             <h4>{item.label}</h4>
+            <f:variable name="count" value="{item.usage.count -> f:format.number(thousandsSeparator: '.', decimalSeparator: '', decimals: 0)}" />
+            <f:variable name="limit" value="{item.usage.limit -> f:format.number(thousandsSeparator: '.', decimalSeparator: '', decimals: 0)}" />
+            <f:variable name="percentage">{item.usage.count / item.usage.limit * 100}</f:variable>
+            <f:if condition="{percentage} >= 98">
+                <f:variable name="severity" value="warning" />
+            </f:if>
+            <f:if condition="{percentage} >= 100">
+                <f:variable name="severity" value="danger" />
+            </f:if>
             <p>
-                <b>{f:translate(key: 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.count')}</b>: {item.usage.count -> f:format.number(thousandsSeparator: '.', decimalSeparator: '', decimals: 0)}
-                <br>
-                <b>{f:translate(key: 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.limit')}</b>: {item.usage.limit -> f:format.number(thousandsSeparator: '.', decimalSeparator: '', decimals: 0)}
+                <f:translate
+                    key="LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.message"
+                    arguments="{0: count, 1: limit}"
+                />
             </p>
-            <f:variable name="procss">{item.usage.count / item.usage.limit * 100}</f:variable>
             <div class="progress" role="progressbar" aria-label="Usage" aria-valuenow="{procss}" aria-valuemin="0" aria-valuemax="100" style="height: 50%">
-                <div class="progress-bar" style="width: {procss}%">{item.usage.count -> f:format.number(thousandsSeparator: '.', decimalSeparator: '', decimals: 0)}</div>
+                <div class="progress-bar" style="width: {percentage}%; --bs-progress-bar-bg: var(--bs-{severity -> f:or(alternative: 'info')});">&nbsp;</div>
             </div>
         </div>
     </f:for>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -199,12 +199,24 @@
 			</trans-unit>
 
 			<trans-unit id="usages.toolbar-label">
-				<source>DeepL Translate Limit</source>
+				<source>DeepL Translate Quota</source>
 				<target>DeepL Übersetzung Limit</target>
+			</trans-unit>
+			<trans-unit id="usages.toolbar.message">
+				<source>%s / %s</source>
+				<target>%s / %s</target>
 			</trans-unit>
 			<trans-unit id="usages.toolbar-information">
 				<source>Information not available</source>
 				<target>Information nicht verfügbar</target>
+			</trans-unit>
+			<trans-unit id="usages.flashmassage.title">
+				<source>DeepL usage and quota</source>
+				<target>DeepL Nutzung und Limits</target>
+			</trans-unit>
+			<trans-unit id="usages.flashmassage.limit.description">
+				<source>DeepL translations for current billing period: %s of %s characters</source>
+				<target>DeepL Übersetzungen für den aktuellen Abrechnungszeitraum: %s von %s Zeichen</target>
 			</trans-unit>
 
 			<!-- Widget -->
@@ -213,20 +225,16 @@
 				<target>DeepL Verwendung</target>
 			</trans-unit>
 			<trans-unit id="widgets.deepltranslate.widget.useswidget.description">
-				<source></source>
-				<target></target>
+				<source>Show a DeepL usage bar</source>
+				<target>Zeige einen Fortschrittsbalken für die DeepL Nutzung</target>
 			</trans-unit>
 			<trans-unit id="widgets.deepltranslate.widget.useswidget.character">
 				<source>Character</source>
 				<target>Zeichen</target>
 			</trans-unit>
-			<trans-unit id="widgets.deepltranslate.widget.useswidget.count">
-				<source>Count</source>
-				<target>Zähler</target>
-			</trans-unit>
-			<trans-unit id="widgets.deepltranslate.widget.useswidget.limit">
-				<source>Limit</source>
-				<target>Begrenzung</target>
+			<trans-unit id="widgets.deepltranslate.widget.useswidget.message">
+				<source>DeepL translations for current billing period: %s of %s characters</source>
+				<target>DeepL Übersetzungen für aktuellen Abrechnungszeitraum: %s von %s Zeichen</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -174,16 +174,19 @@
 			</trans-unit>
 
 			<trans-unit id="usages.toolbar-label">
-				<source>DeepL Translate Limit</source>
+				<source>DeepL Translate Quota</source>
+			</trans-unit>
+			<trans-unit id="usages.toolbar.message">
+				<source>%s / %s</source>
 			</trans-unit>
 			<trans-unit id="usages.toolbar-information">
 				<source>Information not available</source>
 			</trans-unit>
 			<trans-unit id="usages.flashmassage.title">
-				<source>DeepL Translate </source>
+				<source>DeepL usage and quota</source>
 			</trans-unit>
 			<trans-unit id="usages.flashmassage.limit.description">
-				<source>DeepL Translate Limit %s / %s</source>
+				<source>DeepL translations for current billing period: %s of %s characters</source>
 			</trans-unit>
 
 			<!-- Translation Access | be_groups -->
@@ -208,16 +211,13 @@
 				<source>DeepL Usage</source>
 			</trans-unit>
 			<trans-unit id="widgets.deepltranslate.widget.useswidget.description">
-				<source></source>
+				<source>Show a DeepL usage bar</source>
 			</trans-unit>
 			<trans-unit id="widgets.deepltranslate.widget.useswidget.character">
 				<source>Character</source>
 			</trans-unit>
-			<trans-unit id="widgets.deepltranslate.widget.useswidget.count">
-				<source>Count</source>
-			</trans-unit>
-			<trans-unit id="widgets.deepltranslate.widget.useswidget.limit">
-				<source>Limit</source>
+			<trans-unit id="widgets.deepltranslate.widget.useswidget.message">
+				<source>DeepL translations for current billing period: %s of %s characters</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Public/Icons/actions-localize-deepl.svg
+++ b/Resources/Public/Icons/actions-localize-deepl.svg
@@ -1,18 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;}
-	.st1{fill:#000000;}
-</style>
-    <rect id="canvas_background" x="0.5" y="7" class="st0" width="16" height="16"/>
-    <g id="g4185">
-	<g id="g4211">
-		<path id="path4213" class="st1" d="M10,8.2c-0.5,0-1-0.4-1-1C9,7.2,9,7.1,9,7L6.7,5.7C6.5,5.8,6.3,5.9,6,5.9c-0.5,0-1-0.4-1-1
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <g class="icon-color">
+        <path id="path4213" class="st1" d="M10,8.2c-0.5,0-1-0.4-1-1C9,7.2,9,7.1,9,7L6.7,5.7C6.5,5.8,6.3,5.9,6,5.9c-0.5,0-1-0.4-1-1
 			s0.4-1,1-1s1,0.5,1,1C7,5,7,5,7,5.1l2.3,1.4C9.5,6.3,9.7,6.2,10,6.2c0.5,0,1,0.4,1,1S10.5,8.2,10,8.2 M7,9.5c0,0.5-0.4,1-1,1
 			s-1-0.4-1-1s0.5-1,1-1c0.2,0,0.5,0.1,0.6,0.2l1.7-1C8.4,8,8.5,8.2,8.7,8.3L7,9.3C7,9.4,7,9.4,7,9.5 M12.9,3.5L8.3,0.8
 			c-0.3-0.2-0.7-0.2-1,0L2.6,3.5C2.2,3.7,2,4,2,4.4l0,5.4c0,0.4,0.2,0.7,0.5,0.9l8,4.7l0-3.3l2.3-1.3c0.3-0.2,0.5-0.5,0.5-0.9l0-5.4
 			C13.4,4.1,13.2,3.7,12.9,3.5"/>
-	</g>
-</g>
+    </g>
 </svg>


### PR DESCRIPTION
Based on formating styles in PR #357 and the desire for a threshold in issue #343 I have
tweaked the severity level determination in all usage bars (flashmessage, system infobox, widget).

Based on warning levels in other software (90%, 98%, 100%) each info box will use a different 
severity color according to the currently used quota.

The widget is a bit more compact now, since it used a lot of whitespace before,
which makes the dashboard unnecessary large.

![Bildschirmfoto vom 2024-09-09 12-09-56](https://github.com/user-attachments/assets/97f78452-7895-479c-83e1-986e3140f6cc)
