### PR TITLE
Conditionally add dashboard widget

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\DependencyInjection\SingletonPass;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Dashboard\WidgetRegistry;
 use WebVision\WvDeepltranslate\Client;
 use WebVision\WvDeepltranslate\ClientInterface;
 use WebVision\WvDeepltranslate\Command\GlossaryCleanupCommand;
@@ -158,18 +159,24 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
             ]
         );
 
-    $services->set('widgets.deepltranslate.widget.useswidget')
-        ->class(UsageWidget::class)
-        ->arg('$view', new Reference('dashboard.views.widget'))
-        ->arg('$options', [])
-        ->tag('dashboard.widget', [
-            'identifier' => 'widgets-deepl-uses',
-            'groupNames' => 'deepl',
-            'title' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.title',
-            'description' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.description',
-            'iconIdentifier' => 'content-widget-list',
-            'height' => 'medium',
-            'width' => 'small',
-        ])
-    ;
+    /**
+     * Check if WidgetRegistry is defined, which means that EXT:dashboard is available.
+     * Registration directly in Services.yaml will break without EXT:dashboard installed!
+     */
+    if ($containerBuilder->hasDefinition(WidgetRegistry::class)) {
+        $services->set('widgets.deepltranslate.widget.useswidget')
+            ->class(UsageWidget::class)
+            ->arg('$view', new Reference('dashboard.views.widget'))
+            ->arg('$options', [])
+            ->tag('dashboard.widget', [
+                'identifier' => 'widgets-deepl-uses',
+                'groupNames' => 'deepl',
+                'title' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.title',
+                'description' => 'LLL:EXT:wv_deepltranslate/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.description',
+                'iconIdentifier' => 'content-widget-list',
+                'height' => 'medium',
+                'width' => 'small',
+            ])
+        ;
+    }
 };

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
 	"suggest": {
         "b13/container": "Just to be loaded after EXT:container",
 		"web-vision/enable-translated-content": "Adds enable translated content button to language columns in page view",
-		"web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl"
+		"web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl",
+		"typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Ensure the DeepL translate usage widget is registered only if the 'dashboard' extension is loaded. This prevents errors in environments where the 'dashboard' extension is not available by execute the cache flush action.

Resolve #360