### PR TITLE
[TASK] Replace `DeepL Mock Api Server` container image

### DIFF
--- a/.ddev/docker-compose.deeplmockserver.yml
+++ b/.ddev/docker-compose.deeplmockserver.yml
@@ -9,7 +9,7 @@ services:
     # This is the name of the container. It is recommended to follow the same
     # name convention used in the main docker-compose.yml file.
     container_name: ddev-${DDEV_SITENAME}-deeplmockserver
-    image: sbuerk/sbuerk-testing-deeplapimockserver:latest
+    image: ghcr.io/web-vision/wv-deeplmockapi-server:latest
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -12,6 +12,33 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '7.4']
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -49,6 +76,33 @@ jobs:
   typoscript:
     name: "Linting TypoScript and TSConfig files"
     runs-on: ubuntu-22.04
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -67,6 +121,33 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -12,6 +12,33 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '8.1']
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -51,6 +78,33 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '8.1', '8.2', '8.3' ]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -434,7 +434,7 @@ IMAGE_SELENIUM="docker.io/selenium/standalone-chrome:4.0.0-20211102"
 IMAGE_MARIADB="docker.io/mariadb:${DBMS_VERSION}"
 IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"
-IMAGE_DEEPL="docker.io/sbuerk/sbuerk-testing-deeplapimockserver:latest"
+IMAGE_DEEPL="ghcr.io/web-vision/wv-deeplmockapi-server:latest"
 
 
 # Detect arm64 and use a seleniarm image.
@@ -629,6 +629,14 @@ case ${TEST_SUITE} in
         # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
         echo "> remove \"dangling\" ghcr.io/typo3/core-testing-* images (those tagged as <none>)"
         ${CONTAINER_BIN} images --filter "reference=ghcr.io/typo3/core-testing-*" --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi -f {}
+        echo ""
+        # pull ghcr.io/web-vision/ versions of those ones that exist locally
+        echo "> pull ghcr.io/web-vision/* versions of those ones that exist locally"
+        ${CONTAINER_BIN} images "ghcr.io/web-vision/*" --format "{{.Repository}}:{{.Tag}}" | xargs -I {} ${CONTAINER_BIN} pull {}
+        echo ""
+        # remove "dangling" ghcr.io/web-vision/ images (those tagged as <none>)
+        echo "> remove \"dangling\" ghcr.io/web-vision/* images (those tagged as <none>)"
+        ${CONTAINER_BIN} images --filter "reference=ghcr.io/web-vision/*" --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi -f {}
         echo ""
         ;;
     *)


### PR DESCRIPTION
> Note that https://github.com/DeepLcom/deepl-mock needs to create a release for the latest tag
> See: https://github.com/DeepLcom/deepl-mock/issues/5

- **[TASK] Switch deeplmockapi server image to `ghcr.io/web-vision/wv-deeplmockapi-server`**
  The used container image for the `DeepL Mock API Server` has
  been outdated. Instead of creating manual build again this
  has now been properly solved by creating a public repository
  for the container image build along with automatic update
  rebuild and tagging. [1][2]
  
  This change now uses the new image instead of the stalled one.
  
  [1] https://github.com/web-vision/wv-deeplmockapi-server
  [2] https://github.com/web-vision/wv-deeplmockapi-server/pkgs/container/wv-deeplmockapi-server
  

- **[TASK] Remove upper version constraint for `deeplcom/deepl-php`**
  Due to the outdated `DeepL Mock Api Server` version testing
  the extension with a newer `deeplcom/deepl-php` client badly
  failed and has been mitigated by adding a composer version
  constraint to avoid breaking dependency versions.
  
  The container image for the `DeepL Mock Api Server` has been
  exchanged with a up-to-date once which rebuilds and releases
  itself automatically.
  
  Used command(s):
  
  ```bash
  composer require --no-update \
    "deeplcom/deepl-php":"^1.6.0"
  ```
  