### PR TITLE
[BUGFIX] Working with glossary without a request not possible

### DIFF
--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: ../../../Classes/Domain/Repository/GlossaryEntryRepository.php
 
 		-
+			message: "#^Cannot call method getLanguageCode\\(\\) on string\\.$#"
+			count: 2
+			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
+
+		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossariesInRootByCurrentPage\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
@@ -37,11 +42,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$page of method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossaryBySourceAndTargetForSync\\(\\) expects array\\{uid\\: int, title\\: string\\}, array\\|null given\\.$#"
-			count: 1
-			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^Parameter \\#3 \\$pageUid of method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossary\\(\\) expects int, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
 			count: 1
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
 
@@ -201,21 +201,6 @@ parameters:
 			path: ../../../Classes/Utility/DeeplBackendUtility.php
 
 		-
-			message: "#^Offset 'pid' does not exist on array\\|null\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of static method WebVision\\\\WvDeepltranslate\\\\Utility\\\\DeeplBackendUtility\\:\\:getPageRecord\\(\\) expects int, int\\|string given\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
-			message: "#^Parameter \\#2 \\$id of static method WebVision\\\\WvDeepltranslate\\\\Utility\\\\DeeplBackendUtility\\:\\:getPageIdFromRecord\\(\\) expects int, int\\|string given\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Utility\\\\HtmlUtility\\:\\:stripSpecificTags\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: ../../../Classes/Utility/HtmlUtility.php
@@ -319,6 +304,76 @@ parameters:
 			message: "#^Parameter \\#2 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) has parameter \\$codes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) has parameter \\$fallbackIdentifiers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildSiteConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:failIfArrayIsNotEmpty\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeSiteConfiguration\\(\\) has parameter \\$overrides with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$errorHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$current of method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
 
 		-
 			message: "#^Cannot access property \\$code on DeepL\\\\Language\\|null\\.$#"

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
 
 		-
-			message: "#^Parameter \\#3 \\$pageUid of method WebVision\\\\WvDeepltranslate\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossary\\(\\) expects int, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 1
-			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
 			message: "#^PHPDoc tag @throws with type Doctrine\\\\DBAL\\\\DBALException\\|Doctrine\\\\DBAL\\\\Driver\\\\Exception is not subtype of Throwable$#"
 			count: 1
 			path: ../../../Classes/Domain/Repository/PageTreeRepository.php
@@ -201,21 +196,6 @@ parameters:
 			path: ../../../Classes/Utility/DeeplBackendUtility.php
 
 		-
-			message: "#^Offset 'pid' does not exist on array\\|null\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of static method WebVision\\\\WvDeepltranslate\\\\Utility\\\\DeeplBackendUtility\\:\\:getPageRecord\\(\\) expects int, int\\|string given\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
-			message: "#^Parameter \\#2 \\$id of static method WebVision\\\\WvDeepltranslate\\\\Utility\\\\DeeplBackendUtility\\:\\:getPageIdFromRecord\\(\\) expects int, int\\|string given\\.$#"
-			count: 1
-			path: ../../../Classes/Utility/DeeplBackendUtility.php
-
-		-
 			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Utility\\\\HtmlUtility\\:\\:stripSpecificTags\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: ../../../Classes/Utility/HtmlUtility.php
@@ -304,6 +284,66 @@ parameters:
 			message: "#^Parameter \\#1 \\$current of method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) has parameter \\$codes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildErrorHandlingConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) has parameter \\$fallbackIdentifiers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildSiteConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:failIfArrayIsNotEmpty\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeSiteConfiguration\\(\\) has parameter \\$overrides with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$errorHandling with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$current of method WebVision\\\\WvDeepltranslate\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
 
 		-
 			message: "#^Cannot access property \\$code on DeepL\\\\Language\\|null\\.$#"

--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -17,33 +17,27 @@ use WebVision\WvDeepltranslate\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\WvDeepltranslate\Exception\LanguageRecordNotFoundException;
 use WebVision\WvDeepltranslate\Service\DeeplService;
 use WebVision\WvDeepltranslate\Service\LanguageService;
+use WebVision\WvDeepltranslate\Service\ProcessingInstruction;
 
 abstract class AbstractTranslateHook
 {
-    /**
-     * @var array{tableName: string|null, id: string|int|null, mode: string|false}
-     */
-    protected static array $coreProcessorsInformation = [
-        'tableName' => null,
-        'id' => null,
-        // @todo rename identifier to "deepl"
-        'mode' => false,
-    ];
-
     protected DeeplService $deeplService;
 
     protected PageRepository $pageRepository;
 
     protected LanguageService $languageService;
+    protected ProcessingInstruction $processingInstruction;
 
     public function __construct(
         PageRepository $pageRepository,
         DeeplService $deeplService,
-        LanguageService $languageService
+        LanguageService $languageService,
+        ProcessingInstruction $processingInstruction
     ) {
         $this->deeplService = $deeplService;
         $this->pageRepository = $pageRepository;
         $this->languageService = $languageService;
+        $this->processingInstruction = $processingInstruction;
     }
 
     /**
@@ -133,9 +127,6 @@ abstract class AbstractTranslateHook
         if ($commandIsProcessed !== false) {
             return;
         }
-
-        self::$coreProcessorsInformation['tableName'] = $table;
-        self::$coreProcessorsInformation['id'] = $id;
-        self::$coreProcessorsInformation['mode'] = $dataHandler->cmdmap['localization']['custom']['mode'] ?? false;
+        $this->processingInstruction->setProcessingInstruction($table, $id, $dataHandler->cmdmap['localization']['custom']['mode'] ?? false);
     }
 }

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -22,13 +22,13 @@ class TranslateHook extends AbstractTranslateHook
         DataHandler $dataHandler
     ): void {
         // Table Information are importen to find deepl configuration for site
-        $tableName = self::$coreProcessorsInformation['tableName'];
+        $tableName = $this->processingInstruction->getProcessingTable();
         if ($tableName === null) {
             return;
         }
 
         // Record Information are importen to find deepl configuration for site
-        $currentRecordId = self::$coreProcessorsInformation['id'];
+        $currentRecordId = $this->processingInstruction->getProcessingId();
         if ($currentRecordId === null) {
             return;
         }
@@ -39,7 +39,7 @@ class TranslateHook extends AbstractTranslateHook
         }
 
         // Translation mode not set to DeepL translate skip the translation
-        if (self::$coreProcessorsInformation['mode'] !== 'deepl') {
+        if ($this->processingInstruction->isDeeplMode() === false) {
             return;
         }
 

--- a/Classes/Service/ProcessingInstruction.php
+++ b/Classes/Service/ProcessingInstruction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Service;
+
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+
+final class ProcessingInstruction
+{
+    protected const PROCESSING_CACHE_IDENTIFIER = 'deepl-processing-cache';
+    private FrontendInterface $runtimeCache;
+
+    public function __construct(
+        FrontendInterface $runtimeCache
+    ) {
+        $this->runtimeCache = $runtimeCache;
+    }
+
+    /**
+     * @param int|string|null $id
+     * @todo harden deeplMode being a pure boolean
+     * @param string|bool $deeplMode
+     */
+    public function setProcessingInstruction(?string $table = null, $id = null, $deeplMode = false): void
+    {
+        $processingInformation = [
+            'tableName' => $table,
+            'id' => $id,
+            'deeplMode' => $deeplMode,
+        ];
+        $this->runtimeCache->set(self::PROCESSING_CACHE_IDENTIFIER, $processingInformation);
+    }
+
+    /**
+     * @return array{
+     *     tableName: ?string,
+     *     id: int|string|null,
+     *     deeplMode: bool|string
+     * }
+     */
+    public function getProcessingInstruction(): array
+    {
+        if (!$this->runtimeCache->has(self::PROCESSING_CACHE_IDENTIFIER)) {
+            return [
+                'tableName' => null,
+                'id' => null,
+                'deeplMode' => false,
+            ];
+        }
+        return $this->runtimeCache->get(self::PROCESSING_CACHE_IDENTIFIER);
+    }
+
+    public function isDeeplMode(): bool
+    {
+        $processingInstructions = $this->getProcessingInstruction();
+
+        return $processingInstructions['deeplMode'] === 'deepl' || $processingInstructions['deeplMode'] === true;
+    }
+
+    public function getProcessingTable(): ?string
+    {
+        $processingInstructions = $this->getProcessingInstruction();
+
+        return $processingInstructions['tableName'];
+    }
+
+    /**
+     * @return int|string|null
+     */
+    public function getProcessingId()
+    {
+        $processingInstructions = $this->getProcessingInstruction();
+
+        return $processingInstructions['id'];
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -29,6 +29,7 @@ use WebVision\WvDeepltranslate\Service\DeeplGlossaryService;
 use WebVision\WvDeepltranslate\Service\DeeplService;
 use WebVision\WvDeepltranslate\Service\IconOverlayGenerator;
 use WebVision\WvDeepltranslate\Service\LanguageService;
+use WebVision\WvDeepltranslate\Service\ProcessingInstruction;
 use WebVision\WvDeepltranslate\Service\UsageService;
 use WebVision\WvDeepltranslate\Widgets\UsageWidget;
 
@@ -84,6 +85,9 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
         ->factory([service(CacheManager::class), 'getCache'])
         ->args(['wvdeepltranslate']);
 
+    $services
+        ->set(ProcessingInstruction::class)
+        ->arg('$runtimeCache', service('cache.runtime'));
     $services
         ->set(DeeplService::class)
         ->public()

--- a/Tests/Functional/Hooks/TranslateHookTest.php
+++ b/Tests/Functional/Hooks/TranslateHookTest.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvDeepltranslate\Hooks\TranslateHook;
 use WebVision\WvDeepltranslate\Service\LanguageService;
+use WebVision\WvDeepltranslate\Service\ProcessingInstruction;
 use WebVision\WvDeepltranslate\Tests\Functional\AbstractDeepLTestCase;
 use WebVision\WvDeepltranslate\Tests\Functional\Fixtures\Traits\SiteBasedTestTrait;
 
@@ -92,6 +93,10 @@ final class TranslateHookTest extends AbstractDeepLTestCase
             ]
         );
         $this->setUpFrontendRootPage(1, [], []);
+
+        /** @var ProcessingInstruction $processingInstruction */
+        $processingInstruction = $this->get(ProcessingInstruction::class);
+        $processingInstruction->setProcessingInstruction(null, null, true);
     }
 
     /**

--- a/Tests/Functional/Regression/Fixtures/Results/translateWithGlossary.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/translateWithGlossary.csv
@@ -1,0 +1,7 @@
+pages,,,,,
+,"uid","pid","title","subtitle","sys_language_uid",l10n_parent
+,1,0,"Deepl-Functional-Test","",0,0
+,2,1,"Glossary","",0,0
+,3,1,"Glossar","",1,2
+,4,1,"proton beam","glossary term",0,0
+,5,1,"Protonenstrahl","Glossareintrag",1,4

--- a/Tests/Functional/Regression/Fixtures/glossary.csv
+++ b/Tests/Functional/Regression/Fixtures/glossary.csv
@@ -1,0 +1,14 @@
+pages
+,"uid","pid",doktype,"title",subtitle,"sys_language_uid","l10n_parent","slug"
+,1,0,1,"Deepl-Functional-Test","",0,0,"/"
+,2,1,254,"Glossary","",0,0,""
+,3,1,254,"Glossar","",1,2,""
+,4,1,1,"proton beam","glossary term",0,0,"/proton-beam"
+tx_wvdeepltranslate_glossaryentry
+,uid,pid,term,sys_language_uid,l10n_parent
+,1,2,"glossary term",0,0
+,2,2,"Glossareintrag",1,1
+"be_users"
+,"uid","pid","tstamp","username","password","admin","disable","starttime","endtime","options","crdate","workspace_perms","deleted","TSconfig","lastlogin","workspace_id"
+# The password is "password"
+,1,0,1366642540,"admin","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1,0,0,0,0,1366642540,1,0,,1371033743,0

--- a/Tests/Functional/Regression/GlossaryRegressionTest.php
+++ b/Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Tests\Functional\Regression;
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Service\DeeplGlossaryService;
+use WebVision\WvDeepltranslate\Tests\Functional\AbstractDeepLTestCase;
+use WebVision\WvDeepltranslate\Tests\Functional\Fixtures\Traits\SiteBasedTestTrait;
+
+final class GlossaryRegressionTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+            ],
+        ],
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'EXTENSIONS' => [
+            'wv_deepltranslate' => [
+                'apiKey' => 'mock_server',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $site = $this->buildSiteConfiguration(1, '/', 'Home');
+
+        $this->writeSiteConfiguration(
+            'acme',
+            $site,
+            [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ]
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/glossary.csv');
+
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER']);
+        GeneralUtility::makeInstance(DeeplGlossaryService::class)
+            ->syncGlossaries(2);
+    }
+
+    /**
+     * @test
+     */
+    public function glossaryIsRespectedOnLocalization(): void
+    {
+        $commandMap = [
+            'pages' => [
+                4 => [
+                    'localize' => 1,
+                ],
+            ],
+            'localization' => [
+                'custom' => [
+                    'mode' => 'deepl',
+                ],
+            ],
+        ];
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], $commandMap);
+        $dataHandler->process_cmdmap();
+
+        self::assertEmpty($dataHandler->errorLog);
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/translateWithGlossary.csv');
+    }
+}

--- a/Tests/Functional/Services/DeeplServiceTest.php
+++ b/Tests/Functional/Services/DeeplServiceTest.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Tests\Functional\Services;
 use DeepL\Language;
 use WebVision\WvDeepltranslate\Domain\Dto\TranslateContext;
 use WebVision\WvDeepltranslate\Service\DeeplService;
+use WebVision\WvDeepltranslate\Service\ProcessingInstruction;
 use WebVision\WvDeepltranslate\Tests\Functional\AbstractDeepLTestCase;
 
 /**
@@ -22,6 +23,10 @@ final class DeeplServiceTest extends AbstractDeepLTestCase
         );
 
         parent::setUp();
+
+        /** @var ProcessingInstruction $processingInstruction */
+        $processingInstruction = $this->get(ProcessingInstruction::class);
+        $processingInstruction->setProcessingInstruction(null, null, true);
 
     }
 

--- a/Tests/Functional/Services/UsageServiceTest.php
+++ b/Tests/Functional/Services/UsageServiceTest.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Tests\Functional\Services;
 use DeepL\Usage;
 use DeepL\UsageDetail;
 use WebVision\WvDeepltranslate\Service\DeeplService;
+use WebVision\WvDeepltranslate\Service\ProcessingInstruction;
 use WebVision\WvDeepltranslate\Service\UsageService;
 use WebVision\WvDeepltranslate\Tests\Functional\AbstractDeepLTestCase;
 
@@ -22,6 +23,10 @@ final class UsageServiceTest extends AbstractDeepLTestCase
         );
 
         parent::setUp();
+
+        /** @var ProcessingInstruction $processingInstruction */
+        $processingInstruction = $this->get(ProcessingInstruction::class);
+        $processingInstruction->setProcessingInstruction(null, null, true);
     }
 
     /**


### PR DESCRIPTION
The DeeplBackendUtility tried to detect the current working page by guessing the page id via the global request. In some cases no request is given, like on CLI calls. Avoiding errors not using the glossary when not calling translation via backend, a new service `ProcessingInstruction` is added, saving the current instructions inside the global runtime cache. This information can now get detected in every point of the translation and allows a correct detection of the current working page including a valid glossary, if one exists.

A regression test is added demonstrating the glossary is now detected and respected, even if no request is set up.