### PR TITLE
[BUGFIX] Set correct autoconfigure for ProcessingInstruction

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -12,11 +12,13 @@ use DeepL\Language;
 use DeepL\TextResult;
 use DeepL\TranslateTextOptions;
 use DeepL\Usage;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 
 /**
  * @internal No public usage
  */
+#[AsAlias(id: ClientInterface::class, public: true)]
 final class Client extends AbstractClient
 {
     /**

--- a/Classes/Controller/Backend/AjaxController.php
+++ b/Classes/Controller/Backend/AjaxController.php
@@ -6,10 +6,18 @@ namespace WebVision\Deepltranslate\Core\Controller\Backend;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+use TYPO3\CMS\Backend\Attribute\Controller;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use WebVision\Deepltranslate\Core\Configuration;
 
-// @todo use #[Controller] if 12.4+ only support is established, see: TYPO3\CMS\Backend\Attribute\Controller;
+/**
+ * Controller for fetching the DeepL settings via Ajax route for usage in JavaScript inside the backend
+ *
+ * Configured backend ajax route: deepl_check_configuration
+ *
+ * @internal No public API
+ */
+#[Controller]
 final class AjaxController
 {
     private Configuration $configuration;

--- a/Classes/Domain/Dto/CurrentPage.php
+++ b/Classes/Domain/Dto/CurrentPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Domain\Dto;
 
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use WebVision\Deepltranslate\Core\Event\DeepLGlossaryIdEvent;
 
 /**
@@ -14,8 +15,9 @@ use WebVision\Deepltranslate\Core\Event\DeepLGlossaryIdEvent;
  * detecting the right page,
  * for example, while detecting a glossary.
  *
- * @see DeepLGlossaryIdEvent for an usage example
+ * @see DeepLGlossaryIdEvent for a usage example
  */
+#[Exclude]
 final class CurrentPage
 {
     public function __construct(

--- a/Classes/Domain/Dto/TranslateContext.php
+++ b/Classes/Domain/Dto/TranslateContext.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Domain\Dto;
 
-class TranslateContext
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+/**
+ * DTO providing the data shipped to DeepL translation.
+ */
+#[Exclude]
+final class TranslateContext
 {
     protected string $content = '';
 

--- a/Classes/Form/Item/SiteConfigSupportedLanguageItemsProcFunc.php
+++ b/Classes/Form/Item/SiteConfigSupportedLanguageItemsProcFunc.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Form\Item;
 
 use DeepL\Language;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
 
-class SiteConfigSupportedLanguageItemsProcFunc
+/**
+ * Adds DeepL related fields to the Site configuration
+ */
+#[Autoconfigure(public: true)]
+final class SiteConfigSupportedLanguageItemsProcFunc
 {
     private DeeplService $deeplService;
 

--- a/Classes/Form/TranslationDropdownGenerator.php
+++ b/Classes/Form/TranslationDropdownGenerator.php
@@ -23,10 +23,6 @@ use WebVision\Deepltranslate\Core\Utility\DeeplBackendUtility;
  */
 final class TranslationDropdownGenerator
 {
-    public function __construct()
-    {
-    }
-
     /**
      * @param iterable<SiteLanguage> $siteLanguages
      * @throws \Doctrine\DBAL\Exception

--- a/Classes/Form/User/HasFormalitySupport.php
+++ b/Classes/Form/User/HasFormalitySupport.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Form\User;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
 
-class HasFormalitySupport
+/**
+ * Checks a language having support for formality or not.
+ */
+#[Autoconfigure(public: true)]
+final class HasFormalitySupport
 {
     private DeeplService $deeplService;
 

--- a/Classes/Hooks/AllowLanguageSynchronizationHook.php
+++ b/Classes/Hooks/AllowLanguageSynchronizationHook.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
-class AllowLanguageSynchronizationHook
+/**
+ * Changes the `l10n_state` for fields with allowLanguageSynchronisation enabled to custom.
+ * This is required to allow overriding the translation.
+ */
+#[Autoconfigure(public: true)]
+final class AllowLanguageSynchronizationHook
 {
     public function processDatamap_beforeStart(DataHandler $dataHandler): void
     {
@@ -25,11 +31,7 @@ class AllowLanguageSynchronizationHook
 
                     $columnConfig = $GLOBALS['TCA'][$table]['columns'][$column];
 
-                    if (isset($columnConfig['config']['behaviour'])
-                        && is_array($columnConfig['config']['behaviour'])
-                        && isset($columnConfig['config']['behaviour']['allowLanguageSynchronization'])
-                        && (bool)$columnConfig['config']['behaviour']['allowLanguageSynchronization'] === true
-                    ) {
+                    if ((bool)($columnConfig['config']['behaviour']['allowLanguageSynchronization'] ?? false) === true) {
                         $l10nState[$column] = (($columnConfig['l10n_mode'] ?? '') === 'prefixLangTitle')
                             ? 'custom'
                             : 'parent';

--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Page\PageRenderer;
 
+/**
+ * Adds the labels from deepltranslate_core to the backend, so they are available, as the default core functionality
+ * is not working
+ */
+#[Autoconfigure(public: true)]
 final class PageRendererHook
 {
     /**

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -12,7 +13,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 
-class TranslateHook extends AbstractTranslateHook
+/**
+ * The main translation rendering on localization.
+ */
+#[Autoconfigure(public: true)]
+final class TranslateHook extends AbstractTranslateHook
 {
     /**
      * @param array{uid: int} $languageRecord

--- a/Classes/Hooks/UsageProcessAfterFinishHook.php
+++ b/Classes/Hooks/UsageProcessAfterFinishHook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -13,7 +14,12 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Service\UsageService;
 
-class UsageProcessAfterFinishHook
+/**
+ * This hook adds a FlashMessage, if the usage quota is reaching a critical level, so editors can take care
+ * on and ensure to either increase their quota in DeepL or stop translating to keep the hard limit untouched.
+ */
+#[Autoconfigure(public: true)]
+final class UsageProcessAfterFinishHook
 {
     private UsageService $usageService;
 
@@ -25,9 +31,7 @@ class UsageProcessAfterFinishHook
 
     public function processCmdmap_afterFinish(DataHandler $dataHandler): void
     {
-        if (!isset($dataHandler->cmdmap['localization']['custom']['mode'])
-            || $dataHandler->cmdmap['localization']['custom']['mode'] !== 'deepl'
-        ) {
+        if (!isset($dataHandler->cmdmap['deepltranslate'])) {
             return;
         }
 

--- a/Classes/Service/DeeplService.php
+++ b/Classes/Service/DeeplService.php
@@ -7,6 +7,8 @@ namespace WebVision\Deepltranslate\Core\Service;
 use DeepL\Language;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use WebVision\Deepltranslate\Core\ClientInterface;
@@ -15,6 +17,10 @@ use WebVision\Deepltranslate\Core\Event\DeepLGlossaryIdEvent;
 use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 use WebVision\Deepltranslate\Core\Utility\DeeplBackendUtility;
 
+/**
+ * Main entry point for connecting TYPO3 backend to the DeepL API
+ */
+#[Autoconfigure(public: true)]
 final class DeeplService implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
@@ -25,6 +31,7 @@ final class DeeplService implements LoggerAwareInterface
     private ProcessingInstruction $processingInstruction;
 
     public function __construct(
+        #[Autowire(service: 'cache.deepltranslateCore')]
         FrontendInterface $cache,
         ClientInterface $client,
         ProcessingInstruction $processingInstruction,

--- a/Classes/Service/IconOverlayGenerator.php
+++ b/Classes/Service/IconOverlayGenerator.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Service;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 
 /**
  * @internal not part of public deepl extension api
  */
+#[Autoconfigure(public: true)]
 final class IconOverlayGenerator
 {
     private IconFactory $iconFactory;

--- a/Classes/Service/LanguageService.php
+++ b/Classes/Service/LanguageService.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Service;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 
+/**
+ * Service for detecting correct target and source languages from DeepL
+ *
+ * @internal No public API
+ */
+#[Autoconfigure(public: true)]
 final class LanguageService
 {
     protected DeeplService $deeplService;

--- a/Classes/Service/ProcessingInstruction.php
+++ b/Classes/Service/ProcessingInstruction.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Service;
 
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 
+/**
+ * This class defines instructions, how to work within DeepL translations
+ * @internal No public API
+ */
+#[Autoconfigure(public: true)]
 final class ProcessingInstruction
 {
     protected const PROCESSING_CACHE_IDENTIFIER = 'deepl-processing-cache';
     private FrontendInterface $runtimeCache;
 
     public function __construct(
+        #[Autowire(service: 'cache.runtime')]
         FrontendInterface $runtimeCache
     ) {
         $this->runtimeCache = $runtimeCache;

--- a/Classes/Service/UsageService.php
+++ b/Classes/Service/UsageService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Service;
 
 use DeepL\Usage;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Localization\Locales;
@@ -13,6 +14,10 @@ use WebVision\Deepltranslate\Core\ClientInterface;
 use WebVision\Deepltranslate\Core\Event\Listener\UsageToolBarEventListener;
 use WebVision\Deepltranslate\Core\Hooks\UsageProcessAfterFinishHook;
 
+/**
+ * Service for getting the current count and limit of DeepL API
+ */
+#[Autoconfigure(public: true)]
 final class UsageService implements UsageServiceInterface
 {
     public function __construct(

--- a/Classes/Widgets/UsageWidget.php
+++ b/Classes/Widgets/UsageWidget.php
@@ -15,6 +15,9 @@ use WebVision\Deepltranslate\Core\Service\UsageService;
 /**
  * `EXT:dashboard` widget compatible with TYPO3 v12 to display deepl api usage.
  *
+ * Cannot be autoconfigured, as this class depends on EXT:dashboard, which is not installed in every system.
+ * Registration and configuring is done in Configuration/Services.php
+ *
  * @internal implementation only and not part of public API.
  */
 final class UsageWidget implements RequestAwareWidgetInterface, WidgetInterface

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -5,34 +5,13 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use TYPO3\CMS\Backend\View\BackendViewFactory;
-use TYPO3\CMS\Core\DependencyInjection\SingletonPass;
 use TYPO3\CMS\Dashboard\WidgetRegistry;
-use WebVision\Deepltranslate\Core\Form\Item\SiteConfigSupportedLanguageItemsProcFunc;
-use WebVision\Deepltranslate\Core\Form\User\HasFormalitySupport;
-use WebVision\Deepltranslate\Core\Hooks\TranslateHook;
 use WebVision\Deepltranslate\Core\Service\UsageService;
 use WebVision\Deepltranslate\Core\Widgets\UsageWidget;
 
 return function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder) {
     $services = $containerConfigurator
         ->services();
-
-    $containerBuilder
-        ->registerForAutoconfiguration(TranslateHook::class)
-        ->addTag('deepl.TranslateHook');
-    $containerBuilder
-        ->registerForAutoconfiguration(SiteConfigSupportedLanguageItemsProcFunc::class)
-        ->addTag('deepl.SiteConfigSupportedLanguageItemsProcFunc');
-    $containerBuilder
-        ->registerForAutoconfiguration(HasFormalitySupport::class)
-        ->addTag('deepl.HasFormalitySupport');
-
-    $containerBuilder
-        ->addCompilerPass(new SingletonPass('deepl.TranslateHook'));
-    $containerBuilder
-        ->addCompilerPass(new SingletonPass('deepl.SiteConfigSupportedLanguageItemsProcFunc'));
-    $containerBuilder
-        ->addCompilerPass(new SingletonPass('deepl.HasFormalitySupport'));
 
     /**
      * Check if WidgetRegistry is defined, which means that EXT:dashboard is available.

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,29 +13,6 @@ services:
     factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
     arguments: ['deepltranslate_core']
 
-  WebVision\Deepltranslate\Core\Service\:
-    resource: '../Classes/Service/*'
-    public: true
-
-  WebVision\Deepltranslate\Core\Hooks\:
-    resource: '../Classes/Hooks/*'
-    public: true
-
-  WebVision\Deepltranslate\Core\Service\ProcessingInstruction:
-    arguments:
-      $runtimeCache: '@cache.runtime'
-
-  WebVision\Deepltranslate\Core\Service\DeeplService:
-    public: true
-    arguments:
-      $cache: '@cache.deepltranslateCore'
-
-  WebVision\Deepltranslate\Core\Controller\Backend\AjaxController:
-    public: true
-
-  WebVision\Deepltranslate\Core\ClientInterface:
-    class: WebVision\Deepltranslate\Core\Client
-
   WebVision\Deepltranslate\Core\Event\Listener\RenderLocalizationSelect:
     tags:
       - name: 'event.listener'


### PR DESCRIPTION
During testing in another extension, it showed up, that `ProcessingInstruction` was not configured correctly. Change the autoload for this class and adopt all other classes using php attributes instead of registration via `Services.yaml`. With this change the autoload is made on the class, where it is needed and reduces the code inside the `Services.yaml` to the minimum.