### PR TITLE
[BUGFIX] Resolve source language from record correctly

### DIFF
--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Hooks;
 
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 
@@ -27,20 +30,7 @@ final class TranslateHook extends AbstractTranslateHook
         array $languageRecord,
         DataHandler $dataHandler
     ): void {
-        // Table Information are importen to find deepl configuration for site
-        $tableName = $this->processingInstruction->getProcessingTable();
-        if ($tableName === null) {
-            return;
-        }
-
-        // Record Information are importen to find deepl configuration for site
-        $currentRecordId = $this->processingInstruction->getProcessingId();
-        if ($currentRecordId === null) {
-            return;
-        }
-
-        // Wenn you will translate file metadata use the extension "web-vision/deepltranslate-assets"
-        if ($tableName === 'sys_file_metadata') {
+        if (MathUtility::canBeInterpretedAsInteger($content)) {
             return;
         }
 
@@ -49,11 +39,38 @@ final class TranslateHook extends AbstractTranslateHook
             return;
         }
 
+        // Table Information are important to find deepl configuration for site
+        $tableName = $this->processingInstruction->getProcessingTable();
+        if ($tableName === null) {
+            return;
+        }
+
+        // Record Information are important to find deepl configuration for site
+        $currentRecordId = $this->processingInstruction->getProcessingId();
+        if ($currentRecordId === null) {
+            return;
+        }
+
+        // `sys_file_metadata` translation needs additional care and is handled by private addon
+        // "web-vision/deepltranslate-assets", opt out here for now based on that reasoning.
+        if ($tableName === 'sys_file_metadata') {
+            return;
+        }
+
         $translatedContent = '';
 
-        $pageId = $this->findCurrentParentPage($tableName, (int)$currentRecordId);
+        $currentRecord = BackendUtility::getRecord($tableName, $currentRecordId);
+        if ($currentRecord === null) {
+            return;
+        }
+
+        $currentRecordLanguage = 0;
+        $pageId = $this->findCurrentParentPage($tableName, $currentRecord);
         try {
             $siteInformation = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId);
+            if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['languageField'])) {
+                $currentRecordLanguage = $currentRecord[$GLOBALS['TCA'][$tableName]['ctrl']['languageField']];
+            }
         } catch (SiteNotFoundException $e) {
             $siteInformation = null;
         }
@@ -63,13 +80,35 @@ final class TranslateHook extends AbstractTranslateHook
         }
 
         try {
-            $translatedContext = $this->createTranslateContext($content, (int)$languageRecord['uid'], $siteInformation);
-
+            $sourceLanguageRecord = $this->languageService->getSourceLanguage($siteInformation, (int)$currentRecordLanguage);
+        } catch (\Throwable $e) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Source language not supported by DeepL. Possibly wrong Site configuration. Message: %s',
+                    $e->getMessage(),
+                ),
+                1768994529,
+                $e,
+            );
+        }
+        try {
+            $targetLanguageRecord = $this->languageService->getTargetLanguage($siteInformation, (int)$languageRecord['uid']);
+        } catch (\Throwable $e) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Target language not supported by DeepL. Possibly wrong Site configuration. Message: %s',
+                    $e->getMessage(),
+                ),
+                1768994563,
+                $e,
+            );
+        }
+        try {
+            $translatedContext = $this->createTranslateContextForRecords($content, $sourceLanguageRecord, $targetLanguageRecord);
             $translatedContent = $this->deeplService->translateContent($translatedContext);
-
             if ($translatedContent === '') {
                 $this->flashMessages(
-                    'Translation not successful', // ToDo use locallang label
+                    'Translation not successful', // @todo Use locallang label
                     '',
                     ContextualFeedbackSeverity::INFO
                 );

--- a/Classes/Service/LanguageService.php
+++ b/Classes/Service/LanguageService.php
@@ -28,12 +28,25 @@ final class LanguageService
     /**
      * @return array{uid: int, title: string, language_isocode: string, languageCode: string}
      */
-    public function getSourceLanguage(Site $currentSite): array
+    public function getSourceLanguage(Site $currentSite, int $languageId = 0): array
     {
-        $languageIsoCode = $currentSite->getDefaultLanguage()->getLocale()->getLanguageCode();
+        try {
+            $language = $currentSite->getLanguageById($languageId);
+        } catch (\Exception $e) {
+            if ($e->getCode() === 1522960188) {
+                throw new LanguageRecordNotFoundException(
+                    sprintf('Language "%d" in site "%s" not found.', $languageId, $currentSite->getIdentifier()),
+                    1764155930,
+                    $e,
+                );
+            }
+            throw $e;
+        }
+
+        $languageIsoCode = $language->getLocale()->getLanguageCode();
         $sourceLanguageRecord = [
-            'uid' => $currentSite->getDefaultLanguage()->getLanguageId(),
-            'title' => $currentSite->getDefaultLanguage()->getTitle(),
+            'uid' => $language->getLanguageId(),
+            'title' => $language->getTitle(),
             'language_isocode' => strtoupper($languageIsoCode),
             'languageCode' => strtoupper($languageIsoCode),
         ];


### PR DESCRIPTION
TYPO3 provides a translation modal workflow and allows
to specify the source language to translate from and
the source content element records based on selected
language.

The hook implementation of `EXT:deepltranslate_core`
recieves the correct source record, but does not use
it to resolve the source language from it and instead
uses always default language for it.

In most cases, DeepL is still able to properly translate
the content from a non-default language record even if
the wrong language has been passed. This is not ensured
and a correct resolving **must be** done alone based on
the fact that subsequent hooks or events should get this
also right through the translation context created.

To acccomplish a correct resolving of the source language
and use it properly, this change does following:

* `AbstractTranslateHook::createTranslateContextForRecords()`
  is introduced with a new signature as replacement for the
  now internally deprecated `createTranslateContext()` method.

  Main difference is, that the new method operates on passed
  language records and removing the target language resolving
  from it.

  Introducing a new method is done to avoid a breaking behaviour,
  albeit only internally.

* `AbstractTranslateHook::findCurrentParentPage()` is changed
  to allow passing now `int|array` as second argument, which
  is the database record (new) or the record id (old) helping
  to reduce Database queries in the chain. The integer based
  value is kept for now as it is used within addons providing
  custom translation hook implementation based on the abstract.

  This is considered non-breaking.

* `TranslateHook::processTranslateTo_copyAction()` is modified
  to resoulve source and target language records based on passed
  record directy and using the new method from the abstract to
  create the translation context based on the records.

* Minor corrections on code comments and additional todo's are
  done as side changes.