### PR TITLE
[TASK] DPL-158: Streamline icons registration

### DIFF
--- a/Classes/Event/Listener/UsageToolBarEventListener.php
+++ b/Classes/Event/Listener/UsageToolBarEventListener.php
@@ -7,6 +7,7 @@ namespace WebVision\Deepltranslate\Core\Event\Listener;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use WebVision\Deepltranslate\Core\Exception\ApiKeyNotSetException;
 use WebVision\Deepltranslate\Core\Service\UsageService;
@@ -46,7 +47,7 @@ final readonly class UsageToolBarEventListener
                 $this->usageService->formatNumber($usage->character->count),
                 $this->usageService->formatNumber($usage->character->limit)
             ),
-            'actions-localize-deepl',
+            sprintf('actions-localize-deepl-%s', ((new Typo3Version())->getMajorVersion())),
             $this->usageService->determineSeverityForSystemInformation($usage->character->count, $usage->character->limit),
         );
     }

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -104,7 +105,7 @@ final class DeeplBackendUtility
         } else {
             $localizeIconMarkup = GeneralUtility::makeInstance(IconFactory::class)
                 ->getIcon(
-                    'actions-localize-deepl',
+                    sprintf('actions-localize-deepl-%s', ((new Typo3Version())->getMajorVersion())),
                     IconSize::SMALL,
                 )->render();
         }

--- a/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
+++ b/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Site\Entity\Site;
@@ -34,8 +35,6 @@ use WebVision\Deepltranslate\Core\Utility\DeeplBackendUtility;
  * supporting only translate operations for the translate mode.
  *
  * @internal and not part of public API.
- * @todo Needs possible adoption for TYPO3 14.3 (LTS) due to pending interface/signature change,
- *       and the main reason why current branch and extension version is limited to `~14.2.0`.
  */
 final readonly class DeeplTranslateLocalizationHandler implements LocalizationHandlerInterface
 {
@@ -76,12 +75,7 @@ final readonly class DeeplTranslateLocalizationHandler implements LocalizationHa
      */
     public function getIconIdentifier(): string
     {
-        return 'actions-localize-deepl-13';
-        // @todo Albeit being a simple copy of the TYPO3 v13 icon file
-        //       and properly registered in `Configuration/Icons.php`
-        //       the icon was not shown in the `deepl-instance-v14`,
-        //       but as the v13 works pretty fine we simply use that.
-        // return 'actions-localize-deepl-14';
+        return sprintf('actions-localize-deepl-%s', ((new Typo3Version())->getMajorVersion()));
     }
 
     public function isAvailable(LocalizationInstructions $instructions): bool

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,20 +5,6 @@ use WebVision\Deepltranslate\Core\Access\AccessRegistry;
 defined('TYPO3') or die();
 
 (function () {
-    $iconProviderConfiguration = [
-        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class => [
-            'actions-localize-deepl' => ['source' => 'EXT:deepltranslate_core/Resources/Public/Icons/actions-localize-deepl.svg'],
-            'actions-localize-google' => ['source' => 'EXT:deepltranslate_core/Resources/Public/Icons/actions-localize-google.svg'],
-        ],
-    ];
-
-    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-    foreach ($iconProviderConfiguration as $provider => $iconConfiguration) {
-        foreach ($iconConfiguration as $identifier => $option) {
-            $iconRegistry->registerIcon($identifier, $provider, $option);
-        }
-    }
-
     /** @var AccessRegistry $accessRegistry */
     $accessRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(AccessRegistry::class);
     $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['deepltranslate'] ??= [];


### PR DESCRIPTION
`ext_tables.php` contains acient icon registration
for google icon, but also for deepl icon. Modern
registration with `Configuration/Icons.php` exists
and this change removes the unneeded icon, removes
the registration in `ext_tables.php` and adjusts
some places in the code base to use the new icon
identifiers.

This prepares one step further to drop `ext_tables.php`
completley and avoide the deprecation for TYP3 v14.3.
