### PR TITLE
[FEATURE] DPL-158: Autoregister `AccessItemInterface` for custom permission handling

### DIFF
--- a/Classes/Access/AccessItemInterface.php
+++ b/Classes/Access/AccessItemInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Access;
 
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(name: AccessItemInterface::class)]
 interface AccessItemInterface
 {
     /**

--- a/Classes/Access/AccessRegistry.php
+++ b/Classes/Access/AccessRegistry.php
@@ -4,42 +4,126 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Access;
 
-use TYPO3\CMS\Core\SingletonInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
 
-final class AccessRegistry implements SingletonInterface
+#[Autoconfigure(public: true)]
+final class AccessRegistry implements ContainerInterface
 {
     /**
-     * @var AccessItemInterface[]
+     * @var array<string, AccessItemInterface>
      */
-    private static $access = [];
+    private array $items = [];
 
-    public function addAccess(AccessItemInterface $accessItem): void
+    /**
+     * @param iterable<AccessItemInterface> $items
+     */
+    public function __construct(
+        #[AutowireIterator(tag: AccessItemInterface::class, excludeSelf: true)]
+        iterable $items,
+    ) {
+        foreach ($items as $item) {
+            if (!$item instanceof AccessItemInterface) {
+                throw new AutowiringFailedException(
+                    self::class,
+                    sprintf(
+                        'Item "%s" for `$items` must be instance of "%s".',
+                        (is_object($item) ? $item::class : gettype($item)),
+                        AccessItemInterface::class,
+                    ),
+                    1776942850,
+                );
+            }
+            $this->items[$item->getIdentifier()] = $item;
+        }
+    }
+
+    public function get(string $id): ?AccessItemInterface
     {
-        self::$access[] = $accessItem;
+        return $this->items[$id] ?? null;
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->get($id) instanceof AccessItemInterface;
     }
 
     /**
-     * @return AccessItemInterface[]
+     * @return array<string, AccessItemInterface>
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param AccessItemInterface $accessItem
+     * @deprecated since `6.0.0` and will be removed in `7.0.0`.
+     */
+    public function addAccess(AccessItemInterface $accessItem): void
+    {
+        trigger_error(
+            sprintf(
+                '"%s" is deprecated and can be removed and are added by the '
+                . 'dependency injection container based on "%s" automatically.',
+                __METHOD__,
+                AccessItemInterface::class,
+            ),
+            E_USER_DEPRECATED,
+        );
+    }
+
+    /**
+     * @deprecated since `6.0.0` and will be removed in `7.0.0`.
+     * @todo web-vision/deepltranslate-core:>=7.0.0 remove breaking.
+     */
+    public function getAccess(string $identifier): ?AccessItemInterface
+    {
+        trigger_error(
+            sprintf(
+                '"%s" is deprecated. Use "%s" instead.',
+                __METHOD__,
+                self::class . '::get()'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return $this->get($identifier);
+    }
+
+    /**
+     * @deprecated since `6.0.0` and will be removed in `7.0.0`.
+     * @todo web-vision/deepltranslate-core:>=7.0.0 remove breaking.
+     */
+    public function hasAccess(string $identifier): bool
+    {
+        trigger_error(
+            sprintf(
+                '"%s" is deprecated. Use "%s" instead.',
+                'AccessRegistry::hasAccess()',
+                'AccessRegistry::has()'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return $this->has($identifier);
+    }
+
+    /**
+     * @return array<string, AccessItemInterface>
+     * @deprecated since `6.0.0` and will be removed in `7.0.0`.
+     * @todo web-vision/deepltranslate-core:>=7.0.0 remove breaking.
      */
     public function getAllAccess(): array
     {
-        return self::$access;
-    }
-
-    public function getAccess(string $identifier): ?AccessItemInterface
-    {
-        foreach (self::$access as $accessItem) {
-            if ($accessItem->getIdentifier() === $identifier) {
-                return $accessItem;
-            }
-        }
-
-        return null;
-    }
-
-    public function hasAccess(string $identifier): bool
-    {
-        $object = $this->getAccess($identifier);
-        return $object !== null;
+        trigger_error(
+            sprintf(
+                '"%s" is deprecated. Use "%s" instead.',
+                __METHOD__,
+                self::class . '::getItems()'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return $this->getItems();
     }
 }

--- a/Classes/Event/Listener/ApplyCustomPermOptionsEventListener.php
+++ b/Classes/Event/Listener/ApplyCustomPermOptionsEventListener.php
@@ -23,7 +23,7 @@ final class ApplyCustomPermOptionsEventListener
     {
         $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['deepltranslate'] ??= [];
         $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['deepltranslate']['header'] = 'Deepl Translate Access';
-        foreach ($this->accessRegistry->getAllAccess() as $access) {
+        foreach ($this->accessRegistry->getItems() as $access) {
             $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['deepltranslate']['items'][$access->getIdentifier()] = [
                 $access->getTitle(),
                 $access->getIconIdentifier(),

--- a/Documentation/Changelog/6.0/Breaking-RemovedAutotranslateMode.rst
+++ b/Documentation/Changelog/6.0/Breaking-RemovedAutotranslateMode.rst
@@ -1,6 +1,6 @@
 ..  include:: /Includes.rst.txt
 
-..  _breaking-1775514670:
+..  _breaking-removed-autotranslate-mode-1775514670:
 
 ======================================
 Breaking: Removed `Autotranslate Mode`

--- a/Documentation/Changelog/6.0/Breaking-RemovedDeeplTranslateViewHelper.rst
+++ b/Documentation/Changelog/6.0/Breaking-RemovedDeeplTranslateViewHelper.rst
@@ -1,6 +1,6 @@
 ..  include:: /Includes.rst.txt
 
-..  _breaking-1775413934:
+..  _breaking-removed-deepltranslateviewhelper-1775413934:
 
 ============================================
 Breaking: Removed `DeeplTranslateViewHelper`

--- a/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
+++ b/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
@@ -1,6 +1,6 @@
 ..  include:: /Includes.rst.txt
 
-..  _breaking-1773683717:
+..  _breaking-removed-typo3v12-support-1773683717:
 
 ===================================
 Breaking: Removed TYPO3 v12 support

--- a/Documentation/Changelog/6.0/Deprecation-AccessRegistryMethods.rst
+++ b/Documentation/Changelog/6.0/Deprecation-AccessRegistryMethods.rst
@@ -1,0 +1,157 @@
+..  include:: /Includes.rst.txt
+
+..  _deprecation-accessregistry-methods-1777019642:
+
+=====================================
+Deprecation: `AccessRegistry` methods
+=====================================
+
+Description
+===========
+
+Following :php:`\WebVision\Deepltranslate\Core\Access\AccessRegistry` methods
+has been deprecated:
+
+*   :php-short:`addAccess()` because access items are gathered based on the
+    :php-short:`\WebVision\Deepltranslate\Core\Access\AccessItemInterface`
+    and added through the constructor by the DI container. Calling this method
+    does not add anything and emits now a :php:`E_USER_DEPRECATED` error.
+
+*   :php:`getAllAccess()` is now deprecated and triggers a :php:`E_USER_DEPRECATED`
+    error. Use :php:`getItems()` instead.
+
+*   :php:`getAccess()` is now deprecated and triggers a :php:`E_USER_DEPRECATED`
+    error. Use :php:`get()` instead.
+
+*   :php:`hasAccess()` is now deprecated and triggers a :php:`E_USER_DEPRECATED`
+    error. Use `has()` instead.
+
+Impact
+======
+
+Calling deprecated :php:`\WebVision\Deepltranslate\Core\Access\AccessRegistry`
+methods triggers a :php:`E_USER_DEPRECATED` error.
+
+
+Affected installations
+======================
+
+All installations that call one of the deprecated
+:php:`\WebVision\Deepltranslate\Core\Access\AccessRegistry` methods triggers a
+:php:`E_USER_DEPRECATED` error. Use the above mentioned replacements or remove
+the `addAccess()` calls in `ext_localconf.php`.
+
+Migration
+=========
+
+addAccess()
+-----------
+
+To register additional :php-short:`\WebVision\Deepltranslate\Core\Access\AccessItemInterface`
+the approach have been to provide following code in `EXT:my_ext/ext_localconf.php`:
+
+..  code-block:: php
+    :caption: EXT:my_ext/ext_localconf.php
+
+    <?php
+
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+    use WebVision\Deepltranslate\Core\Access\AccessRegistry;
+
+    $accessRegistry = GeneralUtility::makeInstance(AccessRegistry::class);
+    $accessRegistry->addAccess(new CustomAccessItem());
+
+This is no longer required and does not do anything except triggering an
+:php:`E_USER_DEPRECATED` error and can be simply removed.
+
+In case dual extension version support is required encapsulate it into a
+condition, for example:
+
+..  code-block:: php
+    :caption: EXT:my_ext/ext_localconf.php
+
+    <?php
+
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+    use WebVision\Deepltranslate\Core\Access\AccessRegistry;
+    use WebVision\Deepltranslate\Core\TranslatorInterface;
+
+    // @todo web-vision/deepltranslate-core:>=6.0.0 Remove complete condition
+    //       block once lowest supported deepltranslate-core extension version
+    //       has been raised to 6.0.0 or higher.
+    if (class_exists(TranslatorInterface::class) === false) {
+        $accessRegistry = GeneralUtility::makeInstance(AccessRegistry::class);
+        $accessRegistry->addAccess(new CustomAccessItem());
+    }
+
+getAllAccess()
+--------------
+
+:php:`getAllAccess()` can be replaced simply using the new `get()` method:
+
+..  code-block:: diff
+    :caption: EXT:my_ext/Classes/SomeClass.php
+
+     <?php
+
+     namespace MyVendor\MyExt;
+
+     final class SomeClass {
+         public function __construct(
+             private AccessRegistry $accessRegistry,
+         ) {}
+
+         public function someMethod(): void
+         {
+    -       $allRegisteredAccessItems = $this->accessRegistry->getAllAccess();
+    +       // `getItems()` returns now the identifiers as keys and `array_values()`
+    +       // ensures to deal only with the items like with previous `getAllAccess()`.
+    +       $allRegisteredAccessItems = array_values($this->accessRegistry->getItems());
+
+             foreach($allRegisteredAccessItems as $accessItem) {
+                 // ... do something with the access item
+             }
+         }
+     }
+
+hasAccess(), getAccess()
+------------------------
+
+Deprecated :php:`hasAccess()` and `getAccess()` can be simply replaced by their
+new counter methods based on the now used :php:`\Psr\Container\ContainerInterface`:
+
+..  code-block:: diff
+    :caption: EXT:my_ext/Classes/SomeClass.php
+
+     <?php
+
+     namespace MyVendor\MyExt;
+
+     final class SomeClass {
+         public function __construct(
+             private AccessRegistry $accessRegistry,
+         ) {}
+
+         public function hasAccess(): bool
+         {
+            $accessIdentifier = '';
+    -       if (!$this->accessRegistry->hasAccess($accessIdentifier)) {
+    +       if (!$this->accessRegistry->has($accessIdentifier)) {
+              // access does not exists, take this as allowed.
+              return true;
+            }
+
+    -       $accessItem = $this->accessRegistry->getAccess($accessIdentifier);
+    +       $accessItem = $this->accessRegistry->get($accessIdentifier);
+            return $this->getBackendUserAuthentication()->check(
+                'custom_options',
+                sprintf('deepltranslate:%s', $accessItem->getIdentifier()),
+            );
+         }
+
+         private function getBackendUserAuthentication(): BackendUserAuthentication
+         {
+             return $GLOBALS['BE_USER'];
+         }
+     }
+

--- a/Documentation/Changelog/6.0/Feature-32051-ExtbaseQueryExpressionBuilderForOrderings.rst
+++ b/Documentation/Changelog/6.0/Feature-32051-ExtbaseQueryExpressionBuilderForOrderings.rst
@@ -1,0 +1,74 @@
+..  include:: /Includes.rst.txt
+
+..  _feature-automatic-registration-of-accessiteminterface-1777020217:
+
+========================================================
+Feature: Automatic registration of `AccessItemInterface`
+========================================================
+
+
+Description
+===========
+
+`EXT:deepltranslate_core` provides the :php-short:`\WebVision\Deepltranslate\Core\Access\AccessItemInterface`
+to define access subtypes to `use as Custom Permission Options <https://docs.typo3.org/permalink/t3coreapi:custom-permissions>`_
+grouped as `deepltranslate`.
+
+These items are now automatically registered through the Symfony Dependency
+Injection container by simply providing autoconfigured classes implementing
+:php-short:`\WebVision\Deepltranslate\Core\Access\AccessItemInterface`.
+
+No manual registration required anymore.
+
+..  note::
+
+    See also `deprecated AccessRegistry methods <deprecation-accessregistry-methods-1777019642>`_
+    to deal with deprecated methods and avoid deprecation log entries.
+
+Example
+-------
+
+Implement custom access class:
+
+..  code-block:: php
+    :caption: EXT:my_ext/Classes/Access/CustomAccess.php
+
+    <?php
+
+    namespace MyVendor\MyExt\Access;
+
+    use WebVision\Deepltranslate\Core\Access\AccessItemInterface;
+
+    final class CustomAccess implements AccessItemInterface
+    {
+        public function getIdentifier(): string
+        {
+            return 'customAccess';
+        }
+
+        public function getTitle(): string
+        {
+            return 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:be_groups.deepltranslate_access.items.customAccess.title';
+        }
+
+        public function getDescription(): string
+        {
+            return 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:be_groups.deepltranslate_access.items.customAccess.description';
+        }
+
+        public function getIconIdentifier(): string
+        {
+            return 'custom-access-logo';
+        }
+    }
+
+Impact
+======
+
+Classes implementing :php-short:`\WebVision\Deepltranslate\Core\Access\AccessItemInterface`
+defined in extensions are now automatically registered and possible provide any
+access items which have not been registered manually before.
+
+This can be mitigated by using :php:`#[Exclude]` attribute on the class or exclude
+it from the autoconfigure load configuration in `Configuration/Services.yaml`.
+

--- a/Documentation/Changelog/Changelog-6-combined.rst
+++ b/Documentation/Changelog/Changelog-6-combined.rst
@@ -1,16 +1,17 @@
 .. include:: /Includes.rst.txt
 
-..  _changelog-v2-byType:
+..  _changelog-v6-byType:
 
 ===================
-2.x Changes by type
+6.x Changes by type
 ===================
 
 This lists all changes to the Academic Base extension of minor versions
 grouped by their type.
 
 ..  contents:: Table of contents
-..  _changelog-v2-bc:
+..  _changelog-v6-bc:
+
 Breaking Changes
 ================
 
@@ -19,9 +20,10 @@ Breaking Changes
     :titlesonly:
     :glob:
 
-    Changelog/2.*/Breaking-*
+    6.*/Breaking-*
 
-..  _changelog-v2-feat:
+..  _changelog-v6-feat:
+
 Features
 ========
 
@@ -30,9 +32,10 @@ Features
     :titlesonly:
     :glob:
 
-    Changelog/2.*/Feature-*
+    6.*/Feature-*
 
-..  _changelog-v2-dep:
+..  _changelog-v6-dep:
+
 Deprecations
 ============
 
@@ -41,9 +44,10 @@ Deprecations
     :titlesonly:
     :glob:
 
-    Changelog/2.*/Deprecation-*
+    6.*/Deprecation-*
 
-..  _changelog-v2-imp:
+..  _changelog-v6-imp:
+
 Important notes
 ===============
 
@@ -52,4 +56,4 @@ Important notes
     :titlesonly:
     :glob:
 
-    /Changelog/2.*/Important-*
+    6.*/Important-*

--- a/Tests/Functional/Access/AccessRegistryTest.php
+++ b/Tests/Functional/Access/AccessRegistryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Tests\Functional\Access;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use WebVision\Deepltranslate\Core\Access\AccessItemInterface;
+use WebVision\Deepltranslate\Core\Access\AccessRegistry;
+use WebVision\Deepltranslate\Core\Access\AllowedTranslateAccess;
+use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
+
+final class AccessRegistryTest extends AbstractDeepLTestCase
+{
+    /**
+     * @return AllowedTranslateAccess[]
+     */
+    private static function getAllDefaultAccessItemsInExpectedOrder(): array
+    {
+        return [
+            new AllowedTranslateAccess(),
+        ];
+    }
+
+    public static function deepltranslateCoreDefaultAccessItems(): \Generator
+    {
+        $items = self::getAllDefaultAccessItemsInExpectedOrder();
+        foreach ($items as $item) {
+            yield $item->getIdentifier() => [
+                'identifier' => $item->getIdentifier(),
+                'item' => $item,
+            ];
+        }
+    }
+
+    #[DataProvider('deepltranslateCoreDefaultAccessItems')]
+    #[Test]
+    public function hasExpectedAccessItem(string $identifier, AccessItemInterface $item): void
+    {
+        $this->assertTrue($this->get(AccessRegistry::class)->has($identifier));
+    }
+
+    #[DataProvider('deepltranslateCoreDefaultAccessItems')]
+    #[Test]
+    public function getReturnsExpectedAccessItem(string $identifier, AccessItemInterface $item): void
+    {
+        $this->assertSame($identifier, $this->get(AccessRegistry::class)->get($identifier)?->getIdentifier());
+    }
+
+    public static function verifyAllDefaultAccessItemsAreRegisteredDataSets(): \Generator
+    {
+        yield 'EXT:deepltranslate_core' => [
+            'expected' => array_map(fn(AccessItemInterface $item) => $item->getIdentifier(), array_values(self::getAllDefaultAccessItemsInExpectedOrder())),
+        ];
+    }
+
+    /**
+     * @param string[] $expected
+     */
+    #[DataProvider('verifyAllDefaultAccessItemsAreRegisteredDataSets')]
+    #[Test]
+    public function verifyAllDefaultAccessItemsAreRegistered(array $expected): void
+    {
+        $this->assertSame($expected, array_map(fn(AccessItemInterface $item) => $item->getIdentifier(), array_values($this->get(AccessRegistry::class)->getItems())));
+    }
+}

--- a/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+++ b/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional\Regression;
 
+use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
@@ -72,7 +73,7 @@ final class LocalizationInlineRegressionTest extends AbstractDeepLTestCase
             ->createFromUserPreferences($GLOBALS['BE_USER']);
     }
 
-    /** @test */
+    #[Test]
     public function ensureInlineElementsTranslationOnLocalization(): void
     {
         $commandMap = [

--- a/Tests/Functional/Regression/PreviewTranslationInformationTest.php
+++ b/Tests/Functional/Regression/PreviewTranslationInformationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional\Regression;
 
+use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -99,9 +100,7 @@ final class PreviewTranslationInformationTest extends AbstractDeepLTestCase
             ->createFromUserPreferences($GLOBALS['BE_USER']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function previewTranslationInformationIsRenderedForTranslatedPage(): void
     {
         $styles = [];

--- a/Tests/Unit/Access/AccessRegistryTest.php
+++ b/Tests/Unit/Access/AccessRegistryTest.php
@@ -5,35 +5,151 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Tests\Unit\Access;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 use WebVision\Deepltranslate\Core\Access\AccessItemInterface;
 use WebVision\Deepltranslate\Core\Access\AccessRegistry;
 
 #[CoversClass(AccessRegistry::class)]
-class AccessRegistryTest extends UnitTestCase
+final class AccessRegistryTest extends UnitTestCase
 {
     #[Test]
-    public function registerAccessStoresTheAccessCorrectly(): void
+    public function hasReturnsFalseIfIdentifierDoesNotExists(): void
     {
-        $accessRegistry = new AccessRegistry();
-
-        $identifier = 'testIdentifier';
-
-        $accessObject = $this->createMock(AccessItemInterface::class);
-        $accessObject->expects($this->once())->method('getIdentifier')->willReturn($identifier);
-
-        $accessRegistry->addAccess($accessObject);
-        $object = $accessRegistry->getAccess($identifier);
-
-        $this->assertSame($accessObject, $object);
+        $this->assertFalse((new AccessRegistry([]))->has('not-existing-identifier'));
     }
 
     #[Test]
-    public function getAccessReturnsNullForNonExistentIdentifier(): void
+    public function hasReturnsTrueIfIdentifierExists(): void
     {
-        $accessRegistry = new AccessRegistry();
+        $identifier = 'mock-identifier';
+        $accessItemMock = $this->createMock(AccessItemInterface::class);
+        $accessItemMock->expects($this->exactly(1))->method('getIdentifier')->willReturn($identifier);
+        $this->assertTrue((new AccessRegistry([$accessItemMock]))->has($identifier));
+    }
 
-        $this->assertNull($accessRegistry->getAccess('nonExistentIdentifier'));
+    #[Test]
+    public function getReturnsNullIfIdentifierDoesNotExists(): void
+    {
+        $this->assertNull((new AccessRegistry([]))->get('not-existing-identifier'));
+    }
+
+    #[Test]
+    public function getReturnsExpectedExistingAccessItem(): void
+    {
+        $accessItemMock = $this->createMock(AccessItemInterface::class);
+        $accessItemMock->expects($this->exactly(1))->method('getIdentifier')->willReturn('mock-identifier');
+        $this->assertSame($accessItemMock, (new AccessRegistry([$accessItemMock]))->get('mock-identifier'));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function addAccessTriggersDeprecationAndDoesNotAddItem(): void
+    {
+        $accessRegistry = new AccessRegistry([]);
+        $identifier = 'testIdentifier';
+
+        $accessItemMock = $this->createMock(AccessItemInterface::class);
+        $accessItemMock->expects($this->never())->method('getIdentifier')->willReturn($identifier);
+
+        $this->expectUserDeprecationMessage(
+            '"WebVision\Deepltranslate\Core\Access\AccessRegistry::addAccess" is deprecated '
+            . 'and can be removed and are added by the dependency injection container based on '
+            . '"WebVision\Deepltranslate\Core\Access\AccessItemInterface" automatically.'
+        );
+
+        $accessRegistry->addAccess($accessItemMock);
+        $this->assertSame([], (new \ReflectionProperty($accessRegistry, 'items'))->getValue($accessRegistry));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function getAccessReturnsNullForNonExistentIdentifierAndTriggersExpectedDeprecation(): void
+    {
+        $this->expectUserDeprecationMessage(
+            '"WebVision\Deepltranslate\Core\Access\AccessRegistry::getAccess" is deprecated. '
+            . 'Use "WebVision\Deepltranslate\Core\Access\AccessRegistry::get()" instead.'
+        );
+
+        $this->assertNull((new AccessRegistry([]))->getAccess('nonExistentIdentifier'));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function getAccessReturnsExpectedItemAndTriggersExpectedDeprecation(): void
+    {
+        $identifier = 'testIdentifier';
+        $accessItemMock = $this->createMock(AccessItemInterface::class);
+        $accessItemMock->expects($this->exactly(1))->method('getIdentifier')->willReturn($identifier);
+
+        $this->expectUserDeprecationMessage(
+            '"WebVision\Deepltranslate\Core\Access\AccessRegistry::getAccess" is deprecated. '
+            . 'Use "WebVision\Deepltranslate\Core\Access\AccessRegistry::get()" instead.'
+        );
+
+        $this->assertSame($accessItemMock, (new AccessRegistry([$accessItemMock]))->getAccess($identifier));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function hasAccessReturnsFalseForNonExistingIdentifierAndTriggersDeprecation(): void
+    {
+        $identifier = 'nonExistingIdentifier';
+
+        $this->expectUserDeprecationMessage(
+            '"AccessRegistry::hasAccess()" is deprecated. Use "AccessRegistry::has()" instead.'
+        );
+
+        $this->assertFalse((new AccessRegistry([]))->hasAccess($identifier));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function hasAccessReturnsTrueForExistingIdentifierAndTriggersDeprecation(): void
+    {
+        $identifier = 'existingIdentifier';
+        $accessItemMock = $this->createMock(AccessItemInterface::class);
+        $accessItemMock->expects($this->exactly(1))->method('getIdentifier')->willReturn($identifier);
+
+        $this->expectUserDeprecationMessage(
+            '"AccessRegistry::hasAccess()" is deprecated. Use "AccessRegistry::has()" instead.'
+        );
+
+        $this->assertTrue((new AccessRegistry([$accessItemMock]))->hasAccess($identifier));
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function getAllAccessReturnsEmptyArrayAndTriggersExpectedDeprecation(): void
+    {
+        $this->expectUserDeprecationMessage(
+            '"WebVision\Deepltranslate\Core\Access\AccessRegistry::getAllAccess" is deprecated. '
+            . 'Use "WebVision\Deepltranslate\Core\Access\AccessRegistry::getItems()" instead.'
+        );
+
+        $this->assertSame([], (new AccessRegistry([]))->getAllAccess());
+    }
+
+    #[IgnoreDeprecations]
+    #[Test]
+    public function getAllAccessReturnsExpectedItemsAndTriggersExpectedDeprecation(): void
+    {
+        $identifier1 = 'testIdentifier1';
+        $accessItemMock1 = $this->createMock(AccessItemInterface::class);
+        $accessItemMock1->expects($this->exactly(1))->method('getIdentifier')->willReturn($identifier1);
+        $identifier2 = 'testIdentifier2';
+        $accessItemMock2 = $this->createMock(AccessItemInterface::class);
+        $accessItemMock2->expects($this->exactly(1))->method('getIdentifier')->willReturn($identifier2);
+        $expected = [
+            $identifier2 => $accessItemMock2,
+            $identifier1 => $accessItemMock1,
+        ];
+        $this->expectUserDeprecationMessage(
+            '"WebVision\Deepltranslate\Core\Access\AccessRegistry::getAllAccess" is deprecated. '
+            . 'Use "WebVision\Deepltranslate\Core\Access\AccessRegistry::getItems()" instead.'
+        );
+
+        $this->assertSame($expected, (new AccessRegistry(array_values($expected)))->getAllAccess());
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -61,7 +61,4 @@ defined('TYPO3') or die();
         ??= [];
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['deepltranslate_core']['backend']
         ??= \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
-
-    $accessRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\WebVision\Deepltranslate\Core\Access\AccessRegistry::class);
-    $accessRegistry->addAccess((new \WebVision\Deepltranslate\Core\Access\AllowedTranslateAccess()));
 })();


### PR DESCRIPTION
This change streamlines the `AccessRegistry` implementation
to a more modern approach gathering access items based on
`AccessItemInterface` and let the DI container handle the
setup.

This includes in detail:

* `AccessRegistry` no longer implements the ancient TYPO3
  `SingletonInterface` in favour of DI shared services.

* `AccessRegistry` now implements the `ContainerInterface`
  following best-practice principales for registry designs
  and adds following new methods:

  * `get(string $id): ?AccessItemInterface`
  * `has(string $id): bool`

* Following methods are now deprecated:

  * `AccessRegistry::addAccess()` because access items are
    gathered based on the `AccessItemInterface` and added
    through the constructor by the DI container. Calling
    this method does not add anything and emits now a
    `E_USER_DEPRECATED` error.

  * `AccessRegistry::getAllAccess()` is now deprecated and
    triggers a `E_USER_DEPRECATED` error. Use `getItems()`
    instead.

  * `AccessRegistry::getAccess()` is now deprecated and
    triggers a `E_USER_DEPRECATED` error. Use `get()`
    instead.

  * `AccessRegistry::hasAccess()` is now depreecated and
    triggers a  `E_USER_DEPRECATED` error. Use `has()`
    instead.

* Extended `AccessRegistry` unit tests to test all methods
  and special the deprecated methods that deprecation is
  triggered.

* Add functional test to test against shipped default
  access items.

* Replace `AccessRegistry::getAllAccess()` with `getItems()`
  in PSR-14 `ApplyCustomPermOptionsEventListener` adding all
  registered access items to

  ```php
  $GLOBALS['TYPO3_CONF_VARS']['BE']
      ['customPermOptions']['deepltranslate']['items'][]
  ```

For two functional tests `@test` annotation are replaced
with `#[Test]` attributes to mitigate phpunit deprecations.
