### PR TITLE
[DOCS] DPL-158: Rename changelog feature file

### DIFF
--- a/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
+++ b/Documentation/Changelog/6.0/Breaking-RemovedTYPO3V12Support.rst
@@ -26,7 +26,8 @@ Extension cannot be installed in that version but does not break otherwise.
 Affected installations
 ======================
 
-TYPO3 v12 or older instances with `EXT:deepltranslate_core` version `5.x`.
+TYPO3 v12 or older instances with :guilabel:`web-vision/deepltranslate-core`
+version `5.x`.
 
 
 Migration

--- a/Documentation/Changelog/6.0/Feature-AddedTYPO3v14Support.rst
+++ b/Documentation/Changelog/6.0/Feature-AddedTYPO3v14Support.rst
@@ -1,0 +1,39 @@
+..  _feature-addedtypo3v14support-1777258656:
+
+================================
+Feature: Added TYPO3 v14 Support
+================================
+
+Description
+===========
+
+:guilabel:`TYPO3 v14.3.*` has been added coming with following changes:
+
+Handling and visual difference between TYPO3 v13 and v14
+--------------------------------------------------------
+
+For `TYPO3 v14` the streamlined and revamped overall localization handling is
+adopted and making use of the new `Localization Handler` feature. That means,
+that the look and feel is different based on the used TYPO3 version even with
+the same extension version. Some examples:
+
+*   TYPO3 v14 localization handler selection:
+
+    ..  figure:: /Images/Editor/page-translation-wizard-select-translate-localization-handler.png
+        :alt: Select `Translate with DeepL` localization handler in TYPO3 v14
+
+*   TYPO3 v13 localization mode selection in `PageLayout module`:
+
+    ..  figure:: /Images/Editor/deepl-localization-mode.png
+        :alt: Select `Translate with DeepL` localization mode in TYPo3 v13
+
+
+Impact
+======
+
+:guilabel:`web-vision/deepltranslate-core` can now be installed and used in
+:guilabel:`TYPO3 v14.3` instances.
+
+Supported features are completely available for TYPO3 v13 and v14, except
+that generic TYPO3 handling is used provided by these versions.
+

--- a/Documentation/Changelog/6.0/Feature-AutomaticRegistrationOfAccessItemInterface.rst
+++ b/Documentation/Changelog/6.0/Feature-AutomaticRegistrationOfAccessItemInterface.rst
@@ -46,12 +46,20 @@ Implement custom access class:
 
         public function getTitle(): string
         {
-            return 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:be_groups.deepltranslate_access.items.customAccess.title';
+            return sprintf(
+                '%s:%s',
+                'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf',
+                'be_groups.deepltranslate_access.items.customAccess.title',
+            );
         }
 
         public function getDescription(): string
         {
-            return 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:be_groups.deepltranslate_access.items.customAccess.description';
+            return sprintf(
+                '%s:%s',
+                'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf',
+                'be_groups.deepltranslate_access.items.customAccess.description',
+            );
         }
 
         public function getIconIdentifier(): string


### PR DESCRIPTION
A TYPO3 Core feature changelog ReST file has been copied
as basis to write the changelog for a feature. While the
content have been modified the filename was not adjusted
to the topic.

The file in question is now renamed to match the content
it provides and reflecting in public hosted documentation
later on.
