### PR TITLE
[DOCS] DPL-158: Remove obsolete genindex

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -108,4 +108,3 @@ for languages supported by `DeepL <https://www.deepl.com/de/docs-api/>`_.
     :hidden:
 
     Sitemap
-    genindex

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,5 +1,0 @@
-=====
-Index
-=====
-
-.. Sphinx will insert here the general index automatically.


### PR DESCRIPTION
This change removes the generated index,
which does not work at all. Having a
empty file listed does not help. Drop it.
