### PR TITLE
[BUGFIX] Avoid DivisionByZero when fetched characterLimit is `0`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v5
-        if: needs.documentation.outputs.comment_id == ''
+        # Skip if PR from fork (https://github.com/peter-evans/create-or-update-comment/issues/444)
+        # or comment-id not empty
+        if: github.repository == github.event.pull_request.head.repo.full_name && needs.documentation.outputs.comment_id == ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
@@ -77,7 +79,9 @@ jobs:
             [badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge
 
       - name: Update Comment
-        if: needs.documentation.outputs.comment_id != ''
+        # Skip if PR from fork (https://github.com/peter-evans/create-or-update-comment/issues/444)
+        # or comment-id empty
+        if: github.repository == github.event.pull_request.head.repo.full_name && needs.documentation.outputs.comment_id != ''
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ needs.documentation.outputs.comment_id }}

--- a/Classes/Service/UsageService.php
+++ b/Classes/Service/UsageService.php
@@ -90,6 +90,9 @@ final readonly class UsageService implements UsageServiceInterface
      */
     public function determineSeverity(int $characterCount, int $characterLimit): ContextualFeedbackSeverity
     {
+        if ($characterLimit === 0) {
+            return ContextualFeedbackSeverity::NOTICE;
+        }
         $quotaUtilization = ($characterCount / $characterLimit) * 100;
         if ($quotaUtilization >= 100) {
             return ContextualFeedbackSeverity::ERROR;
@@ -110,6 +113,9 @@ final readonly class UsageService implements UsageServiceInterface
      */
     public function determineSeverityForSystemInformation(int $characterCount, int $characterLimit): InformationStatus
     {
+        if ($characterLimit === 0) {
+            return InformationStatus::NOTICE;
+        }
         $quotaUtilization = ($characterCount / $characterLimit) * 100;
         if ($quotaUtilization >= 100) {
             return InformationStatus::ERROR;


### PR DESCRIPTION
DeepL seems to return `0` when fetching the current usage stats 
and ending in a `DivisionByZero` error in the `UsageService`.

This change adds a early check before using `0` as divisior in
two places and avoiding the above mentioned error. 

Resolves: #572