### PR TITLE
[BUGFIX] Avoid DivisionByZero when fetched characterLimit is 0

### DIFF
--- a/Classes/Service/UsageService.php
+++ b/Classes/Service/UsageService.php
@@ -91,6 +91,9 @@ final class UsageService implements UsageServiceInterface
      */
     public function determineSeverity(int $characterCount, int $characterLimit): ContextualFeedbackSeverity
     {
+        if ($characterLimit === 0) {
+            return ContextualFeedbackSeverity::NOTICE;
+        }
         $quotaUtilization = ($characterCount / $characterLimit) * 100;
         if ($quotaUtilization >= 100) {
             return ContextualFeedbackSeverity::ERROR;
@@ -111,6 +114,9 @@ final class UsageService implements UsageServiceInterface
      */
     public function determineSeverityForSystemInformation(int $characterCount, int $characterLimit): string
     {
+        if ($characterLimit === 0) {
+            return InformationStatus::STATUS_NOTICE;
+        }
         $quotaUtilization = ($characterCount / $characterLimit) * 100;
         if ($quotaUtilization >= 100) {
             return InformationStatus::STATUS_ERROR;


### PR DESCRIPTION
DeepL seems to return `0` when fetching the current usage stats
and ending in a `DivisionByZero` error in the `UsageService`.

This change adds a early check before using `0` as divisior in
two places and avoiding the above mentioned error.

Resolves: #572 (backport of #573)