### PR TITLE
[BUGFIX] Use `deepltranslate` DataHandler command for single record

### DIFF
--- a/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
+++ b/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
@@ -158,7 +158,7 @@ final readonly class DeeplTranslateLocalizationHandler implements LocalizationHa
         $cmd = [
             $type => [
                 $uid => [
-                    $mode->getDataHandlerCommand() => $targetLanguage,
+                    'deepltranslate' => $targetLanguage,
                 ],
             ],
         ];


### PR DESCRIPTION
TYPO3 v14 revamped the complete localization process introducing
localization handlers and `EXT:deepltranslate_core` implemented
a custom handler to process localization using the `DeepL API`.

`EXT:deepltranslate_core` handle DeepL based localization with
a DataHandler hook reacting on custom `deepltranslate` command
since a long time, which has been adopted but missed to set for
single record localization in the new handler.

This change corrects that and now uses the custom `deepltranslate`
command even for single record localization.

Resolves: #575
