### PR TITLE
[TASK] DPL-158: Introduce PSR-14 event to determine PID=0 site configuration

### DIFF
--- a/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
+++ b/Core14/Backend/Localization/DeeplTranslateLocalizationHandler.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Access\AllowedTranslateAccess;
+use WebVision\Deepltranslate\Core\Core14\Backend\Localization\Event\DetermineRecordPidZeroSiteConfiguration;
 use WebVision\Deepltranslate\Core\Event\DisallowTableFromDeeplTranslateEvent;
 use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException as DeeplTranslateCoreInvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
@@ -335,14 +336,24 @@ final readonly class DeeplTranslateLocalizationHandler implements LocalizationHa
         }
         $recordPid = (int)($record['pid'] ?? 0);
         if ($recordPid === 0) {
-            // @todo How to handle PID=0 records ? Return as invalid for now.
-            // @todo This would automatically rule out `sys_file` and `sys_file_metadata` (FAL) for now,
-            //       and needs to be implemented to get `EXT:deepltranslate_assets` working for TYPO3v14.
-            return [
-                'site' => null,
-                'sourceLanguage' => null,
-                'targetLanguage' => null,
-            ];
+            try {
+                $event = new DetermineRecordPidZeroSiteConfiguration(
+                    mainRecordType: $instructions->mainRecordType,
+                    record: $record,
+                    sourceLanguageId: $instructions->sourceLanguageId,
+                    targetLanguageId: $instructions->targetLanguageId,
+                    site: null,
+                );
+                /** @var DetermineRecordPidZeroSiteConfiguration $event */
+                $event = $this->eventDispatcher->dispatch($event);
+                return $event->getResult();
+            } catch (\Throwable) {
+                return [
+                    'site' => null,
+                    'sourceLanguage' => null,
+                    'targetLanguage' => null,
+                ];
+            }
         }
         return $this->determineSiteInformation(
             $recordPid,

--- a/Core14/Backend/Localization/Event/DetermineRecordPidZeroSiteConfiguration.php
+++ b/Core14/Backend/Localization/Event/DetermineRecordPidZeroSiteConfiguration.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Core14\Backend\Localization\Event;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
+/**
+ * Fired for PID=0 records (not pages) in
+ * {@see DeeplTranslateLocalizationHandler::determineSiteConfigAndSiteLanguageForLocalizationInstructions()}
+ * to allow determination of usable site configuration.
+ *
+ * **Be aware** that this **must** be determininstic, which means source and target language must be for the
+ * same configuration and targetLanguageId only resolves to a single site configuration. Otherwise site config
+ * is not deterministic retrievable and using correct DeepL key is not guaranteed.
+ *
+ * @internal and not part of public API.
+ */
+final class DetermineRecordPidZeroSiteConfiguration
+{
+    /**
+     * @param string $mainRecordType
+     * @param array<string, mixed> $record
+     * @param int $sourceLanguageId
+     * @param int $targetLanguageId
+     * @param Site|null $site
+     */
+    public function __construct(
+        public readonly string $mainRecordType,
+        public readonly array $record,
+        public readonly int $sourceLanguageId,
+        public readonly int $targetLanguageId,
+        public ?Site $site,
+    ) {}
+
+    /**
+     * @return array{site: Site|null, sourceLanguage: SiteLanguage|null, targetLanguage: SiteLanguage|null}
+     */
+    public function getResult(): array
+    {
+        if ($this->site === null) {
+            return [
+                'site' => null,
+                'sourceLanguage' => null,
+                'targetLanguage' => null,
+            ];
+        }
+        $sourceSiteLanguage = $this->getValidSiteLanguage($this->site, $this->sourceLanguageId);
+        $targetSiteLanguage = $this->getValidSiteLanguage($this->site, $this->targetLanguageId);
+        if ($sourceSiteLanguage === null || $targetSiteLanguage === null) {
+            return [
+                'site' => null,
+                'sourceLanguage' => null,
+                'targetLanguage' => null,
+            ];
+        }
+        return [
+            'site' => $this->site,
+            'sourceLanguage' => $sourceSiteLanguage,
+            'targetLanguage' => $targetSiteLanguage,
+        ];
+    }
+
+    private function getValidSiteLanguage(Site $site, int $languageId): ?SiteLanguage
+    {
+        try {
+            return $site->getLanguageById($languageId);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Internal PSR-14 event `DetermineRecordPidZeroSiteConfiguration` is
introduced to provide special determination of site configuration
for PID=0 records. For DeepL this **must** be deterministic because
the determined configuration is not passed through the DataHandler
stack because of lacking support to do so.
