### PR TITLE
[TASK] Blind configuration options

### DIFF
--- a/Classes/Event/Listener/BlindConfigurationOptionsEventListener.php
+++ b/Classes/Event/Listener/BlindConfigurationOptionsEventListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WebVision\Deepltranslate\Core\Event\Listener;
+
+use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
+
+/**
+ * Listen to {@see ModifyBlindedConfigurationOptionsEvent} to hide sensitive data
+ * in the configuration module.
+ */
+final class BlindConfigurationOptionsEventListener
+{
+    public function __invoke(ModifyBlindedConfigurationOptionsEvent $event): void
+    {
+        $options = $event->getBlindedConfigurationOptions();
+
+        if ($event->getProviderIdentifier() === 'confVars') {
+            $options['TYPO3_CONF_VARS']['EXTENSIONS']['deepltranslate_core']['apiKey'] = '******';
+        }
+
+        $event->setBlindedConfigurationOptions($options);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -51,3 +51,9 @@ services:
         identifier: 'deepltranslate-core/translation-dropdown'
         event: WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent
         after: 'deepl-base/default-translation'
+
+  WebVision\Deepltranslate\Core\Event\Listener\BlindConfigurationOptionsEventListener:
+    tags:
+      - name: 'event.listener'
+        identifier: 'deepltranslate-core/blind-configuration-options'
+        event: TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent


### PR DESCRIPTION
Hide sensitive data in configuration module using
the `ModifyBlindedConfigurationOptionsEvent`.

Backport of #582.
