### PR TITLE
[TASK] DPL-158: Provide light/dark theme aware action and logo icon

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -3,15 +3,16 @@
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+use WebVision\Deepl\Base\Imaging\IconProvider\DeeplBaseSvgIconProvider;
 
 return [
     'actions-localize-deepl-13' => [
-        'provider' => SvgIconProvider::class,
-        'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/actions-localize-deepl-v13.svg',
+        'provider' => DeeplBaseSvgIconProvider::class,
+        'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/deepl-mode-aware.svg',
     ],
     'actions-localize-deepl-14' => [
-        'provider' => SvgIconProvider::class,
-        'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/actions-localize-deepl-v14.svg',
+        'provider' => DeeplBaseSvgIconProvider::class,
+        'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/deepl-mode-aware.svg',
     ],
     'deepl-grey-logo' => [
         'provider' => SvgIconProvider::class,
@@ -20,5 +21,9 @@ return [
     'deepl-logo' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/deepl.svg',
+    ],
+    'deepl-logo-mode-aware' => [
+        'provider' => DeeplBaseSvgIconProvider::class,
+        'source' => 'EXT:deepltranslate_core/Resources/Public/Icons/deepl-mode-aware.svg',
     ],
 ];

--- a/Resources/Public/Icons/deepl-mode-aware.svg
+++ b/Resources/Public/Icons/deepl-mode-aware.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+    <rect id="canvas_background" x="0.5" y="7" class="st0" width="16" height="16"/>
+    <g id="g4185">
+	<g id="g4211" class="icon-color" fill="currentColor">
+		<path id="path4213" class="st1" d="M10,8.2c-0.5,0-1-0.4-1-1C9,7.2,9,7.1,9,7L6.7,5.7C6.5,5.8,6.3,5.9,6,5.9c-0.5,0-1-0.4-1-1
+			s0.4-1,1-1s1,0.5,1,1C7,5,7,5,7,5.1l2.3,1.4C9.5,6.3,9.7,6.2,10,6.2c0.5,0,1,0.4,1,1S10.5,8.2,10,8.2 M7,9.5c0,0.5-0.4,1-1,1
+			s-1-0.4-1-1s0.5-1,1-1c0.2,0,0.5,0.1,0.6,0.2l1.7-1C8.4,8,8.5,8.2,8.7,8.3L7,9.3C7,9.4,7,9.4,7,9.5 M12.9,3.5L8.3,0.8
+			c-0.3-0.2-0.7-0.2-1,0L2.6,3.5C2.2,3.7,2,4,2,4.4l0,5.4c0,0.4,0.2,0.7,0.5,0.9l8,4.7l0-3.3l2.3-1.3c0.3-0.2,0.5-0.5,0.5-0.9l0-5.4
+			C13.4,4.1,13.2,3.7,12.9,3.5"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
This change uses now the `DeeplBaseSvgIconProvider` provided by the
`EXT:deepl_base` extension to register `light|dark theme` aware
action icons and logo icons in the `Configuration/Icons.php` file.

That allows `EXT:deepltranslate_core` directly and also addons to
use suiting icons for example on buttons while beeing color scheme
aware.
