### PR TITLE
[TASK] DPL-158: Raise `web-vision/deepl-base:^1.0.4`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4",
-		"web-vision/deepl-base": "^1.0.3@dev",
+		"web-vision/deepl-base": "^1.0.4@dev",
 		"web-vision/deeplcom-deepl-php": "^1.16.1"
 	},
 	"require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
             'extbase' => '12.4.0-13.4.99',
             'fluid' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
-            'deepl_base' => '1.0.3-1.99.99',
+            'deepl_base' => '1.0.4-1.99.99',
             'deeplcom_deeplphp' => '1.16.1-1.99.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
This change raises dependency version constraint to
`web-vision/deepl-base:^1.0.4` to ensure that the
custom icon provider is in place.

Used command(s):

```bash
composer require --no-update \
  'web-vision/deepl-base':'^1.0.4@dev'
```
