### PR TITLE
[BUGFIX] Use correct release url for TER upload version comment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           {
             echo 'terReleaseNotes<<EOF'
-            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo "https://github.com/web-vision/deepltranslate-core/releases/tag/${{ env.version }}"
             echo EOF
           } >> "$GITHUB_ENV"
           echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description

The publish workflow currently generates release note URLs that point to the `fgtclb/academic-persons` repository.

As a result, release links displayed on the extension page redirect users to the wrong GitHub repository.

### Current URL

https://github.com/fgtclb/academic-persons/releases/tag/6.0.3

### Expected URL

https://github.com/web-vision/deepltranslate-core/releases/tag/6.0.3

<img width="1090" height="889" alt="image" src="https://github.com/user-attachments/assets/5ecbdaf6-d9de-460f-a5da-20ace0eaa898" />
