### PR TITLE
[BUGFIX] Use correct release url for TER upload version comment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           {
             echo 'terReleaseNotes<<EOF'
-            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo "https://github.com/web-vision/deepltranslate-core/releases/tag/${{ env.version }}"
             echo EOF
           } >> "$GITHUB_ENV"
           echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"


### PR DESCRIPTION
The public GitHub action workflow mentions the wrong GitHub
repository within the version comment for the TER upload
indicating a missed alignment during copy&paste the workflow
from another repository.

This change modifies the step to mention the correct url in
the future.

Backport of #595
