### PR TITLE
[BUGFIX] DPL-193: Localize inline children through their parent (#503) (5.x)

### DIFF
--- a/Build/patches/typo3-cms-backend-110281-v12-v13.patch
+++ b/Build/patches/typo3-cms-backend-110281-v12-v13.patch
@@ -1,0 +1,69 @@
+diff --git a/Classes/Utility/BackendUtility.php b/Classes/Utility/BackendUtility.php
+index 893f781..f442596 100644
+--- a/Classes/Utility/BackendUtility.php
++++ b/Classes/Utility/BackendUtility.php
+@@ -27,6 +27,7 @@
+ use TYPO3\CMS\Core\Database\Connection;
+ use TYPO3\CMS\Core\Database\ConnectionPool;
+ use TYPO3\CMS\Core\Database\Platform\PlatformInformation;
++use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+ use TYPO3\CMS\Core\Database\Query\QueryHelper;
+ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+@@ -293,10 +294,7 @@
+             $queryBuilder->select('*')
+                 ->from($table)
+                 ->where(
+-                    $queryBuilder->expr()->eq(
+-                        $tcaCtrl['translationSource'] ?? $tcaCtrl['transOrigPointerField'],
+-                        $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
+-                    ),
++                    self::createTranslationParentConstraint($queryBuilder, $tcaCtrl, (int)$uid),
+                     $queryBuilder->expr()->eq(
+                         $tcaCtrl['languageField'],
+                         $queryBuilder->createNamedParameter((int)$language, Connection::PARAM_INT)
+@@ -314,6 +312,44 @@
+         return $recordLocalization;
+     }
+ 
++    /**
++     * Constraint matching all translations of the given record.
++     *
++     * `translationSource` (l10n_source) is preferred, since it is the more precise information for
++     * translation chains. It is however not maintained by all writes - a DataHandler datamap which
++     * creates a translation by only setting the language field and the transOrigPointerField leaves
++     * it empty - so such records are matched by their transOrigPointerField (l10n_parent) instead.
++     * Without that, valid translations would be invisible for callers like
++     * `DataHandler::localize()`, which uses this lookup to prevent duplicate translations.
++     *
++     * @param array $tcaCtrl The `ctrl` section of the table
++     */
++    protected static function createTranslationParentConstraint(
++        QueryBuilder $queryBuilder,
++        array $tcaCtrl,
++        int $uid
++    ): CompositeExpression|string {
++        $uidParameter = $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT);
++        $translationOriginPointerConstraint = $queryBuilder->expr()->eq(
++            $tcaCtrl['transOrigPointerField'],
++            $uidParameter
++        );
++        if (!isset($tcaCtrl['translationSource'])) {
++            return $translationOriginPointerConstraint;
++        }
++
++        return $queryBuilder->expr()->or(
++            $queryBuilder->expr()->eq($tcaCtrl['translationSource'], $uidParameter),
++            $queryBuilder->expr()->and(
++                $queryBuilder->expr()->eq(
++                    $tcaCtrl['translationSource'],
++                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
++                ),
++                $translationOriginPointerConstraint
++            )
++        );
++    }
++
+     /*******************************************
+      *
+      * Page tree, TCA related

--- a/Classes/Domain/Dto/InlineParentReference.php
+++ b/Classes/Domain/Dto/InlineParentReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Domain\Dto;
+
+/**
+ * Describes the connected mode inline (IRRE) relation between a child record and the record owning
+ * it, resolved by {@see \WebVision\Deepltranslate\Core\Service\InlineRelationResolver}.
+ */
+final class InlineParentReference
+{
+    public function __construct(
+        public readonly string $childTable,
+        public readonly int $childUid,
+        public readonly string $parentTable,
+        public readonly string $parentField,
+        public readonly int $parentUid,
+        public readonly string $foreignField,
+    ) {
+    }
+
+    /**
+     * Identifier to compare two resolved references, used to detect ambiguous relation configurations.
+     */
+    public function getIdentifier(): string
+    {
+        return sprintf('%s.%s.%d', $this->parentTable, $this->parentField, $this->parentUid);
+    }
+}

--- a/Classes/Domain/Dto/InlineParentResolution.php
+++ b/Classes/Domain/Dto/InlineParentResolution.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Domain\Dto;
+
+use WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState;
+
+/**
+ * Result of resolving the connected mode inline (IRRE) parent of a record, carrying both the
+ * {@see InlineParentState outcome} and, for a resolved relation, the {@see InlineParentReference}.
+ *
+ * The state lets the caller tell a normal standalone record ({@see InlineParentState::NotInlineChild},
+ * silent) apart from a broken relation configuration ({@see InlineParentState::Ambiguous},
+ * {@see InlineParentState::ParentMissing}, worth reporting to the editor).
+ */
+final class InlineParentResolution
+{
+    private function __construct(
+        public readonly InlineParentState $state,
+        public readonly ?InlineParentReference $reference = null,
+    ) {
+    }
+
+    public static function resolved(InlineParentReference $reference): self
+    {
+        return new self(InlineParentState::Resolved, $reference);
+    }
+
+    public static function notInlineChild(): self
+    {
+        return new self(InlineParentState::NotInlineChild);
+    }
+
+    public static function ambiguous(): self
+    {
+        return new self(InlineParentState::Ambiguous);
+    }
+
+    public static function parentMissing(): self
+    {
+        return new self(InlineParentState::ParentMissing);
+    }
+
+    public function isResolved(): bool
+    {
+        return $this->state === InlineParentState::Resolved;
+    }
+}

--- a/Classes/Domain/Enum/InlineParentState.php
+++ b/Classes/Domain/Enum/InlineParentState.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Domain\Enum;
+
+/**
+ * Outcome of resolving the connected mode inline (IRRE) parent of a record, see
+ * {@see \WebVision\Deepltranslate\Core\Service\InlineRelationResolver::resolveParentReference()}.
+ */
+enum InlineParentState
+{
+    /**
+     * The record is not an inline child in connected mode - the common case for any standalone
+     * record, for example a `tt_content` element placed directly on a page. Must be localized
+     * normally and must not be reported to the editor.
+     */
+    case NotInlineChild;
+
+    /**
+     * The record could be an inline child of more than one parent at the same time, which cannot be
+     * resolved reliably. Points at a broken or conflicting TCA relation configuration and should be
+     * reported to the editor.
+     */
+    case Ambiguous;
+
+    /**
+     * The record points at a parent record through its `foreign_field`, but that parent record does
+     * not exist (any more). Points at broken data and should be reported to the editor.
+     */
+    case ParentMissing;
+
+    /**
+     * The record is an inline child in connected mode and its parent was resolved unambiguously.
+     */
+    case Resolved;
+}

--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
 use WebVision\Deepltranslate\Core\Domain\Dto\TranslateContext;
+use WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState;
 use WebVision\Deepltranslate\Core\Domain\Repository\PageRepository;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
@@ -187,10 +188,23 @@ abstract class AbstractTranslateHook
         // Inline (IRRE) children in connected mode must not be localized on their own: `DataHandler::localize()`
         // does not write the `foreign_field` pointer to the translated parent, which would create a translation
         // not attached to anything. Hand these over to the DataHandler command dealing with inline children.
+        //
+        // A record whose table is used for inline children but which is not one itself - most prominently a
+        // `tt_content` element placed directly on a page - resolves to `NotInlineChild` and is localized
+        // normally below. A broken relation configuration (`Ambiguous`, `ParentMissing`) is skipped and
+        // reported to the editor instead of silently producing a mis-attached translation.
         // @see https://github.com/web-vision/deepltranslate-core/issues/503
-        $inlineParentReference = $this->inlineRelationResolver->resolveParentReference($table, (int)$id);
+        $inlineParentResolution = $this->inlineRelationResolver->resolveParentReference($table, (int)$id);
+        $inlineParentReference = $inlineParentResolution->reference;
         if ($inlineParentReference !== null) {
             $this->localizeInlineChildRecord($inlineParentReference, (int)$value, $dataHandler);
+            $commandIsProcessed = true;
+            return;
+        }
+        if ($inlineParentResolution->state === InlineParentState::Ambiguous
+            || $inlineParentResolution->state === InlineParentState::ParentMissing
+        ) {
+            $this->logBrokenInlineRelation($inlineParentResolution->state, $table, (int)$id);
             $commandIsProcessed = true;
             return;
         }
@@ -289,5 +303,39 @@ abstract class AbstractTranslateHook
         ]);
         $inlineDataHandler->process_cmdmap();
         $dataHandler->errorLog = array_merge($dataHandler->errorLog, $inlineDataHandler->errorLog);
+    }
+
+    /**
+     * Reports a record whose inline relation could not be resolved reliably - an ambiguous relation
+     * configuration or a missing parent record. Such a record is skipped instead of being localized
+     * on its own, which would attach the translation to the wrong parent or to nothing at all. A
+     * broken TCA or broken data is the likely cause, so the editor is informed.
+     */
+    private function logBrokenInlineRelation(InlineParentState $state, string $table, int $uid): void
+    {
+        $message = $state === InlineParentState::Ambiguous
+            ? 'DeepL translation of record "{table}:{uid}" has been skipped, because it matches more than one'
+                . ' inline parent relation and cannot be attached reliably. Check the inline relation'
+                . ' configuration (TCA) of this table.'
+            : 'DeepL translation of inline child record "{table}:{uid}" has been skipped, because the parent'
+                . ' record it points to does not exist. Check the record\'s inline relation.';
+        $messageData = [
+            'table' => $table,
+            'uid' => $uid,
+        ];
+        // `DataHandler::log()` has incompatible signatures in TYPO3 v12 and v13, therefore the
+        // extension logger is used here instead of writing a `sys_log` entry.
+        GeneralUtility::makeInstance(LogManager::class)
+            ->getLogger(__CLASS__)
+            ->info($message, $messageData);
+        $this->flashMessages(
+            str_replace(
+                array_map(static fn (string $key): string => '{' . $key . '}', array_keys($messageData)),
+                array_map(static fn ($value): string => (string)$value, array_values($messageData)),
+                $message
+            ),
+            '',
+            ContextualFeedbackSeverity::WARNING
+        );
     }
 }

--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
 use WebVision\Deepltranslate\Core\Domain\Dto\TranslateContext;
 use WebVision\Deepltranslate\Core\Domain\Repository\PageRepository;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
+use WebVision\Deepltranslate\Core\Service\InlineRelationResolver;
 use WebVision\Deepltranslate\Core\Service\LanguageService;
 use WebVision\Deepltranslate\Core\Service\ProcessingInstruction;
 
@@ -29,6 +33,8 @@ abstract class AbstractTranslateHook
     protected LanguageService $languageService;
     protected ProcessingInstruction $processingInstruction;
 
+    protected InlineRelationResolver $inlineRelationResolver;
+
     public function __construct(
         PageRepository $pageRepository,
         DeeplService $deeplService,
@@ -39,6 +45,15 @@ abstract class AbstractTranslateHook
         $this->pageRepository = $pageRepository;
         $this->languageService = $languageService;
         $this->processingInstruction = $processingInstruction;
+    }
+
+    /**
+     * Setter injection to avoid changing the constructor signature within a maintenance branch.
+     */
+    #[Required]
+    final public function injectInlineRelationResolver(InlineRelationResolver $inlineRelationResolver): void
+    {
+        $this->inlineRelationResolver = $inlineRelationResolver;
     }
 
     /**
@@ -169,6 +184,17 @@ abstract class AbstractTranslateHook
         }
         $this->processingInstruction->setProcessingInstruction($table, $id, true);
 
+        // Inline (IRRE) children in connected mode must not be localized on their own: `DataHandler::localize()`
+        // does not write the `foreign_field` pointer to the translated parent, which would create a translation
+        // not attached to anything. Hand these over to the DataHandler command dealing with inline children.
+        // @see https://github.com/web-vision/deepltranslate-core/issues/503
+        $inlineParentReference = $this->inlineRelationResolver->resolveParentReference($table, (int)$id);
+        if ($inlineParentReference !== null) {
+            $this->localizeInlineChildRecord($inlineParentReference, (int)$value, $dataHandler);
+            $commandIsProcessed = true;
+            return;
+        }
+
         // Following lines are copied from `DataHandler::process_cmdmap()` from 'localize' command switch. Property
         // is protected and the reason we need to use PHP powerfull reflection API to set the wanted value.
         $dataHandlerPropertyReflection = (new \ReflectionProperty($dataHandler, 'useTransOrigPointerField'));
@@ -178,5 +204,68 @@ abstract class AbstractTranslateHook
         $dataHandlerPropertyReflection->setValue($dataHandler, $backupUseTransOrigPointerField);
 
         $commandIsProcessed = true;
+    }
+
+    /**
+     * Localizes an inline child record through its parent record, so TYPO3 writes the `foreign_field`
+     * pointer, the `pid` and the sorting of the created translation.
+     *
+     * Without a translated parent record the child translation cannot be attached to anything. In that
+     * case nothing is created at all, mirroring `DataHandler::inlineLocalizeSynchronize()`, which refuses
+     * to work on a parent record without localization, too.
+     */
+    private function localizeInlineChildRecord(
+        InlineParentReference $reference,
+        int $languageId,
+        DataHandler $dataHandler
+    ): void {
+        $translatedParentRecords = BackendUtility::getRecordLocalization(
+            $reference->parentTable,
+            $reference->parentUid,
+            $languageId
+        );
+        if (!is_array($translatedParentRecords) || $translatedParentRecords === []) {
+            $message = 'DeepL translation of inline child record "{table}:{uid}" has been skipped, because parent'
+                . ' record "{parentTable}:{parentUid}" has no translation for language "{language}" yet. Translate'
+                . ' the parent record first.';
+            $messageData = [
+                'table' => $reference->childTable,
+                'uid' => $reference->childUid,
+                'parentTable' => $reference->parentTable,
+                'parentUid' => $reference->parentUid,
+                'language' => $languageId,
+            ];
+            // `DataHandler::log()` has incompatible signatures in TYPO3 v12 and v13, therefore the
+            // extension logger is used here instead of writing a `sys_log` entry.
+            GeneralUtility::makeInstance(LogManager::class)
+                ->getLogger(__CLASS__)
+                ->info($message, $messageData);
+            $this->flashMessages(
+                str_replace(
+                    array_map(static fn (string $key): string => '{' . $key . '}', array_keys($messageData)),
+                    array_map(static fn ($value): string => (string)$value, array_values($messageData)),
+                    $message
+                ),
+                '',
+                ContextualFeedbackSeverity::WARNING
+            );
+            return;
+        }
+
+        $inlineDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $inlineDataHandler->start([], [
+            $reference->parentTable => [
+                $reference->parentUid => [
+                    'inlineLocalizeSynchronize' => [
+                        'field' => $reference->parentField,
+                        'language' => $languageId,
+                        'action' => 'localize',
+                        'ids' => [$reference->childUid],
+                    ],
+                ],
+            ],
+        ]);
+        $inlineDataHandler->process_cmdmap();
+        $dataHandler->errorLog = array_merge($dataHandler->errorLog, $inlineDataHandler->errorLog);
     }
 }

--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -219,6 +219,28 @@ abstract class AbstractTranslateHook
         int $languageId,
         DataHandler $dataHandler
     ): void {
+        // Note: a translation with an empty `l10n_source` is not found by this lookup, because it
+        // matches `ctrl.translationSource` and only falls back to `ctrl.transOrigPointerField` for
+        // tables without a translation source field. Such records are created by TYPO3 itself, for
+        // example through a plain DataHandler datamap, so an existing parent translation can be
+        // missed here and the child translation is skipped.
+        //
+        // This cannot be worked around inside the extension: `DataHandler::inlineLocalizeSynchronize()`,
+        // which the localization is handed over to, resolves the parent localization with the very
+        // same call, and further DataHandler code paths do so as well. Only the upstream fix repairs
+        // the behaviour:
+        //
+        // - https://forge.typo3.org/issues/110281
+        // - main: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94914
+        // - 14.3: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94916
+        // - 13.4: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94915
+        //
+        // TYPO3 v12.4 has reached ELTS and no longer receives fixes from the public community, so it
+        // will never contain the change. Instances on v12.4 need a composer patch, for which this
+        // extension already ships the tooling (`vaimo/composer-patches` and the `patches/` directory).
+        //
+        // @todo Raise the minimum TYPO3 core version constraint to the releases containing the fix
+        //       above, once they are merged and released, and drop this note.
         $translatedParentRecords = BackendUtility::getRecordLocalization(
             $reference->parentTable,
             $reference->parentUid,

--- a/Classes/Service/InlineRelationResolver.php
+++ b/Classes/Service/InlineRelationResolver.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
+
+/**
+ * Resolves the record owning an inline (IRRE) child record in connected mode, meaning the parent
+ * TCA field uses `foreign_field` to point back from the child to its parent.
+ *
+ * This information is required to localize such a child record on its own: TYPO3 only writes the
+ * `foreign_field` pointer of a localized child when the localization is triggered through the
+ * parent record. Localizing the child directly - through `DataHandler::localize()` - creates a
+ * translation which is not attached to the translated parent and therefore invisible.
+ *
+ * @see https://github.com/web-vision/deepltranslate-core/issues/503
+ */
+#[Autoconfigure(public: true)]
+final class InlineRelationResolver
+{
+    /**
+     * TCA field types which can own child records through a `foreign_field` pointer column.
+     *
+     * @var non-empty-string[]
+     */
+    private const RELATION_FIELD_TYPES = ['inline', 'file'];
+
+    /**
+     * Returns the connected mode inline parent of the given record, or null if the record is not an
+     * inline child in connected mode, if the relation cannot be resolved unambiguously or if the
+     * parent record does not exist.
+     */
+    public function resolveParentReference(string $childTable, int $childUid): ?InlineParentReference
+    {
+        if ($childUid <= 0 || !isset($GLOBALS['TCA'][$childTable])) {
+            return null;
+        }
+        $childRecord = BackendUtility::getRecord($childTable, $childUid);
+        if (!is_array($childRecord)) {
+            return null;
+        }
+
+        $references = [];
+        foreach (($GLOBALS['TCA'] ?? []) as $parentTable => $tableConfiguration) {
+            foreach (($tableConfiguration['columns'] ?? []) as $parentField => $columnConfiguration) {
+                $configuration = $columnConfiguration['config'] ?? [];
+                if (!in_array($configuration['type'] ?? '', self::RELATION_FIELD_TYPES, true)) {
+                    continue;
+                }
+                $parentUid = $this->determineParentUid($childTable, $childRecord, (string)$parentTable, $configuration);
+                if ($parentUid === null) {
+                    continue;
+                }
+                $reference = new InlineParentReference(
+                    childTable: $childTable,
+                    childUid: $childUid,
+                    parentTable: (string)$parentTable,
+                    parentField: (string)$parentField,
+                    parentUid: $parentUid,
+                    foreignField: (string)$configuration['foreign_field'],
+                );
+                $references[$reference->getIdentifier()] = $reference;
+            }
+        }
+
+        if (count($references) !== 1) {
+            // Either no connected mode inline parent at all, or an ambiguous relation configuration
+            // which cannot be resolved reliably. Both must not be handled as inline child.
+            return null;
+        }
+
+        return array_pop($references);
+    }
+
+    /**
+     * @param array<string, mixed> $childRecord
+     * @param array<string, mixed> $configuration
+     */
+    private function determineParentUid(
+        string $childTable,
+        array $childRecord,
+        string $parentTable,
+        array $configuration
+    ): ?int {
+        if (($configuration['foreign_table'] ?? '') !== $childTable) {
+            return null;
+        }
+        if (!empty($configuration['MM'])) {
+            // Relations using an intermediate table do not have a pointer field on the child side.
+            return null;
+        }
+        $foreignField = (string)($configuration['foreign_field'] ?? '');
+        if ($foreignField === '' || !array_key_exists($foreignField, $childRecord)) {
+            return null;
+        }
+        // Child tables shared by multiple parent tables carry the parent table name in a dedicated column.
+        $foreignTableField = (string)($configuration['foreign_table_field'] ?? '');
+        if ($foreignTableField !== ''
+            && (string)($childRecord[$foreignTableField] ?? '') !== $parentTable
+        ) {
+            return null;
+        }
+        // Child tables shared by multiple fields of the same parent table are distinguished by additional columns.
+        foreach (($configuration['foreign_match_fields'] ?? []) as $matchField => $matchValue) {
+            if ((string)($childRecord[$matchField] ?? '') !== (string)$matchValue) {
+                return null;
+            }
+        }
+        $parentUid = (int)($childRecord[$foreignField] ?? 0);
+        if ($parentUid <= 0 || !is_array(BackendUtility::getRecord($parentTable, $parentUid))) {
+            return null;
+        }
+
+        return $parentUid;
+    }
+}

--- a/Classes/Service/InlineRelationResolver.php
+++ b/Classes/Service/InlineRelationResolver.php
@@ -7,6 +7,7 @@ namespace WebVision\Deepltranslate\Core\Service;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
+use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentResolution;
 
 /**
  * Resolves the record owning an inline (IRRE) child record in connected mode, meaning the parent
@@ -50,26 +51,37 @@ final class InlineRelationResolver
     }
 
     /**
-     * Returns the connected mode inline parent of the given record, or null if the record is not an
-     * inline child in connected mode, if the relation cannot be resolved unambiguously or if the
-     * parent record does not exist.
+     * Resolves the connected mode inline parent of the given record.
+     *
+     * The returned {@see InlineParentResolution} distinguishes a normal standalone record - for
+     * example a `tt_content` element placed directly on a page, which shares its table with inline
+     * children but is not one - from a broken relation configuration, so the caller can localize the
+     * former silently and report the latter to the editor.
      */
-    public function resolveParentReference(string $childTable, int $childUid): ?InlineParentReference
+    public function resolveParentReference(string $childTable, int $childUid): InlineParentResolution
     {
         if ($childUid <= 0 || !isset($GLOBALS['TCA'][$childTable])) {
-            return null;
+            return InlineParentResolution::notInlineChild();
         }
         $childRecord = BackendUtility::getRecord($childTable, $childUid);
         if (!is_array($childRecord)) {
-            return null;
+            return InlineParentResolution::notInlineChild();
         }
 
         $references = [];
+        $parentMissing = false;
         foreach ($this->getInlineParentCandidates($childTable) as $candidate) {
             $parentTable = $candidate['parentTable'];
             $configuration = $candidate['configuration'];
             $parentUid = $this->determineParentUid($childRecord, $parentTable, $configuration);
             if ($parentUid === null) {
+                // The record is not attached to this parent field (pointer empty, or a table/match
+                // field discriminator excludes it) - not an inline child through this candidate.
+                continue;
+            }
+            if (!is_array(BackendUtility::getRecord($parentTable, $parentUid))) {
+                // The record points at a parent record that does not exist (any more).
+                $parentMissing = true;
                 continue;
             }
             $reference = new InlineParentReference(
@@ -83,13 +95,19 @@ final class InlineRelationResolver
             $references[$reference->getIdentifier()] = $reference;
         }
 
-        if (count($references) !== 1) {
-            // Either no connected mode inline parent at all, or an ambiguous relation configuration
-            // which cannot be resolved reliably. Both must not be handled as inline child.
-            return null;
+        if (count($references) > 1) {
+            // The record could be an inline child of more than one parent at the same time, which
+            // cannot be resolved reliably - a broken or conflicting relation configuration.
+            return InlineParentResolution::ambiguous();
+        }
+        if (count($references) === 1) {
+            return InlineParentResolution::resolved(array_pop($references));
+        }
+        if ($parentMissing) {
+            return InlineParentResolution::parentMissing();
         }
 
-        return array_pop($references);
+        return InlineParentResolution::notInlineChild();
     }
 
     /**
@@ -154,7 +172,7 @@ final class InlineRelationResolver
             }
         }
         $parentUid = (int)($childRecord[$foreignField] ?? 0);
-        if ($parentUid <= 0 || !is_array(BackendUtility::getRecord($parentTable, $parentUid))) {
+        if ($parentUid <= 0) {
             return null;
         }
 

--- a/Classes/Service/InlineRelationResolver.php
+++ b/Classes/Service/InlineRelationResolver.php
@@ -30,6 +30,26 @@ final class InlineRelationResolver
     private const RELATION_FIELD_TYPES = ['inline', 'file'];
 
     /**
+     * Whether any TCA field can own records of the given table through a `foreign_field` pointer
+     * column, meaning records of that table can be inline children in connected mode.
+     *
+     * In contrast to {@see self::resolveParentReference()} this does not need a record and can
+     * therefore be used at points where the pointer column of a newly created child record has not
+     * been written yet - which is the case for most of the DataHandler processing.
+     */
+    public function isPossibleInlineChildTable(string $childTable): bool
+    {
+        if (!isset($GLOBALS['TCA'][$childTable])) {
+            return false;
+        }
+        foreach ($this->getInlineParentCandidates($childTable) as $ignored) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the connected mode inline parent of the given record, or null if the record is not an
      * inline child in connected mode, if the relation cannot be resolved unambiguously or if the
      * parent record does not exist.
@@ -45,26 +65,22 @@ final class InlineRelationResolver
         }
 
         $references = [];
-        foreach (($GLOBALS['TCA'] ?? []) as $parentTable => $tableConfiguration) {
-            foreach (($tableConfiguration['columns'] ?? []) as $parentField => $columnConfiguration) {
-                $configuration = $columnConfiguration['config'] ?? [];
-                if (!in_array($configuration['type'] ?? '', self::RELATION_FIELD_TYPES, true)) {
-                    continue;
-                }
-                $parentUid = $this->determineParentUid($childTable, $childRecord, (string)$parentTable, $configuration);
-                if ($parentUid === null) {
-                    continue;
-                }
-                $reference = new InlineParentReference(
-                    childTable: $childTable,
-                    childUid: $childUid,
-                    parentTable: (string)$parentTable,
-                    parentField: (string)$parentField,
-                    parentUid: $parentUid,
-                    foreignField: (string)$configuration['foreign_field'],
-                );
-                $references[$reference->getIdentifier()] = $reference;
+        foreach ($this->getInlineParentCandidates($childTable) as $candidate) {
+            $parentTable = $candidate['parentTable'];
+            $configuration = $candidate['configuration'];
+            $parentUid = $this->determineParentUid($childRecord, $parentTable, $configuration);
+            if ($parentUid === null) {
+                continue;
             }
+            $reference = new InlineParentReference(
+                childTable: $childTable,
+                childUid: $childUid,
+                parentTable: $parentTable,
+                parentField: $candidate['parentField'],
+                parentUid: $parentUid,
+                foreignField: (string)$configuration['foreign_field'],
+            );
+            $references[$reference->getIdentifier()] = $reference;
         }
 
         if (count($references) !== 1) {
@@ -77,24 +93,51 @@ final class InlineRelationResolver
     }
 
     /**
+     * All TCA fields owning records of the given table through a `foreign_field` pointer column.
+     *
+     * @return iterable<array{parentTable: non-empty-string, parentField: non-empty-string, configuration: array<string, mixed>}>
+     */
+    private function getInlineParentCandidates(string $childTable): iterable
+    {
+        foreach (($GLOBALS['TCA'] ?? []) as $parentTable => $tableConfiguration) {
+            foreach (($tableConfiguration['columns'] ?? []) as $parentField => $columnConfiguration) {
+                $configuration = $columnConfiguration['config'] ?? [];
+                if (!in_array($configuration['type'] ?? '', self::RELATION_FIELD_TYPES, true)) {
+                    continue;
+                }
+                if (($configuration['foreign_table'] ?? '') !== $childTable) {
+                    continue;
+                }
+                if (!empty($configuration['MM'])) {
+                    // Relations using an intermediate table do not have a pointer field on the child side.
+                    continue;
+                }
+                if ((string)($configuration['foreign_field'] ?? '') === '') {
+                    continue;
+                }
+                if ((string)$parentTable === '' || (string)$parentField === '') {
+                    continue;
+                }
+                yield [
+                    'parentTable' => (string)$parentTable,
+                    'parentField' => (string)$parentField,
+                    'configuration' => $configuration,
+                ];
+            }
+        }
+    }
+
+    /**
      * @param array<string, mixed> $childRecord
      * @param array<string, mixed> $configuration
      */
     private function determineParentUid(
-        string $childTable,
         array $childRecord,
         string $parentTable,
         array $configuration
     ): ?int {
-        if (($configuration['foreign_table'] ?? '') !== $childTable) {
-            return null;
-        }
-        if (!empty($configuration['MM'])) {
-            // Relations using an intermediate table do not have a pointer field on the child side.
-            return null;
-        }
-        $foreignField = (string)($configuration['foreign_field'] ?? '');
-        if ($foreignField === '' || !array_key_exists($foreignField, $childRecord)) {
+        $foreignField = (string)$configuration['foreign_field'];
+        if (!array_key_exists($foreignField, $childRecord)) {
             return null;
         }
         // Child tables shared by multiple parent tables carry the parent table name in a dedicated column.

--- a/Documentation/CorePatches/typo3-cms-backend-110281-v12-v13.patch
+++ b/Documentation/CorePatches/typo3-cms-backend-110281-v12-v13.patch
@@ -1,0 +1,69 @@
+diff --git a/Classes/Utility/BackendUtility.php b/Classes/Utility/BackendUtility.php
+index 893f781..f442596 100644
+--- a/Classes/Utility/BackendUtility.php
++++ b/Classes/Utility/BackendUtility.php
+@@ -27,6 +27,7 @@
+ use TYPO3\CMS\Core\Database\Connection;
+ use TYPO3\CMS\Core\Database\ConnectionPool;
+ use TYPO3\CMS\Core\Database\Platform\PlatformInformation;
++use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+ use TYPO3\CMS\Core\Database\Query\QueryHelper;
+ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+@@ -293,10 +294,7 @@
+             $queryBuilder->select('*')
+                 ->from($table)
+                 ->where(
+-                    $queryBuilder->expr()->eq(
+-                        $tcaCtrl['translationSource'] ?? $tcaCtrl['transOrigPointerField'],
+-                        $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
+-                    ),
++                    self::createTranslationParentConstraint($queryBuilder, $tcaCtrl, (int)$uid),
+                     $queryBuilder->expr()->eq(
+                         $tcaCtrl['languageField'],
+                         $queryBuilder->createNamedParameter((int)$language, Connection::PARAM_INT)
+@@ -314,6 +312,44 @@
+         return $recordLocalization;
+     }
+ 
++    /**
++     * Constraint matching all translations of the given record.
++     *
++     * `translationSource` (l10n_source) is preferred, since it is the more precise information for
++     * translation chains. It is however not maintained by all writes - a DataHandler datamap which
++     * creates a translation by only setting the language field and the transOrigPointerField leaves
++     * it empty - so such records are matched by their transOrigPointerField (l10n_parent) instead.
++     * Without that, valid translations would be invisible for callers like
++     * `DataHandler::localize()`, which uses this lookup to prevent duplicate translations.
++     *
++     * @param array $tcaCtrl The `ctrl` section of the table
++     */
++    protected static function createTranslationParentConstraint(
++        QueryBuilder $queryBuilder,
++        array $tcaCtrl,
++        int $uid
++    ): CompositeExpression|string {
++        $uidParameter = $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT);
++        $translationOriginPointerConstraint = $queryBuilder->expr()->eq(
++            $tcaCtrl['transOrigPointerField'],
++            $uidParameter
++        );
++        if (!isset($tcaCtrl['translationSource'])) {
++            return $translationOriginPointerConstraint;
++        }
++
++        return $queryBuilder->expr()->or(
++            $queryBuilder->expr()->eq($tcaCtrl['translationSource'], $uidParameter),
++            $queryBuilder->expr()->and(
++                $queryBuilder->expr()->eq(
++                    $tcaCtrl['translationSource'],
++                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
++                ),
++                $translationOriginPointerConstraint
++            )
++        );
++    }
++
+     /*******************************************
+      *
+      * Page tree, TCA related

--- a/Documentation/KnownIssues/Index.rst
+++ b/Documentation/KnownIssues/Index.rst
@@ -9,3 +9,55 @@ Translation options not shown
 When API key is not set, *deepltranslate_core* disables all functions.
 Go to :ref:`Settings <extensionConfiguration>` and fix it. Clear cache
 after this.
+
+TYPO3 Core patch required (l10n_source)
+---------------------------------------
+
+Localizing a record whose table declares a translation source field
+(``l10n_source``) - for example content elements built with ``MASK`` - can create
+a **duplicate translation** in the same language. This is the root cause of the
+duplicated translations reported for ``web-vision/deepltranslate-auto-renew`` in
+`#42 <https://github.com/web-vision/deepltranslate-auto-renew/issues/42>`__.
+
+The defect is in the TYPO3 Core, not in this extension:
+``BackendUtility::getRecordLocalization()`` matches existing translations by
+``l10n_source`` when the table defines one and does not fall back to
+``l10n_parent``. A valid translation created without populating ``l10n_source``
+(the usual result of a plain DataHandler datamap, an importer, a migration or
+``MASK``) is not found, so ``DataHandler::localize()`` creates a second one.
+
+The fix is upstream: `forge #110281 <https://forge.typo3.org/issues/110281>`__,
+`Gerrit 94915 (13.4) <https://review.typo3.org/c/Packages/TYPO3.CMS/+/94915>`__.
+TYPO3 v12.4 has reached ELTS and never receives the fix upstream. Until the fix
+is released for v13.4, and permanently for v12.4, instances have to apply it
+through a Composer patch, for example with
+`vaimo/composer-patches <https://github.com/vaimo/composer-patches>`__:
+
+..  code-block:: json
+
+    {
+        "require-dev": {
+            "vaimo/composer-patches": "^6.0.1"
+        },
+        "extra": {
+            "patches": {
+                "typo3/cms-backend": {
+                    "TYPO3 #110281 l10n_source on v12.4 (ELTS, always)": {
+                        "source": "patches/typo3-cms-backend-110281-v12-v13.patch",
+                        "version": ">=12.4.0 <13.0.0"
+                    },
+                    "TYPO3 #110281 l10n_source on v13.4 (until the fix release)": {
+                        "source": "patches/typo3-cms-backend-110281-v12-v13.patch",
+                        "version": ">=13.4.0 <13.4.34"
+                    }
+                }
+            }
+        }
+    }
+
+See the general TYPO3 documentation on applying Composer patches for
+project-specific setup details. The patch used by this extension:
+
+..  literalinclude:: ../CorePatches/typo3-cms-backend-110281-v12-v13.patch
+    :language: diff
+    :caption: typo3-cms-backend-110281-v12-v13.patch

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/Overrides/tt_content.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+// Pointer column back to the inline parent `tx_testinlinerelations_contentparent`, mirroring how
+// EXT:news registers `tx_news_related_news` on `tt_content` as `type => passthrough`. A content
+// element placed directly on a page leaves this at `0`; only a genuine inline child carries the
+// parent uid. This is exactly the value the InlineRelationResolver uses to tell them apart.
+ExtensionManagementUtility::addTCAcolumns('tt_content', [
+    'tx_testinlinerelations_related' => [
+        'label' => 'tx_testinlinerelations_related',
+        'config' => [
+            'type' => 'passthrough',
+        ],
+    ],
+]);

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_declared.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_declared.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Inline (IRRE) child record with the `foreign_field` pointer column configured as
+ * `type => passthrough` in TCA - the variant used by EXT:styleguide.
+ */
+return [
+    'ctrl' => [
+        'title' => 'Inline relation child (pointer field configured in TCA)',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'versioningWS' => true,
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'columns' => [
+        'parentid' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'title, --div--;meta, hidden, sys_language_uid, l10n_parent',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_declared.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_declared.php
@@ -32,6 +32,13 @@ return [
                 'type' => 'passthrough',
             ],
         ],
+        // Second pointer column, used only to construct an ambiguous relation (a child owned by two
+        // parent fields at once), see `tx_testinlinerelations_parent.children_declared_ambiguous`.
+        'parentid_ambiguous' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
         'title' => [
             'exclude' => true,
             'l10n_mode' => 'prefixLangTitle',

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_undeclared.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_child_undeclared.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Inline (IRRE) child record with the `foreign_field` pointer column *not* configured in TCA at
+ * all - only present in `ext_tables.sql`. This is the setup reported in
+ * https://github.com/web-vision/deepltranslate-core/issues/503 and it behaves differently from
+ * the `passthrough` variant, because `DataHandler::fillInFieldArray()` silently drops values of
+ * columns which are unknown to the TCA schema.
+ */
+return [
+    'ctrl' => [
+        'title' => 'Inline relation child (pointer field not configured in TCA)',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'versioningWS' => true,
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'columns' => [
+        'title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'title, --div--;meta, hidden, sys_language_uid, l10n_parent',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_contentparent.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_contentparent.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Inline (IRRE) parent embedding shared `tt_content` records, modelled after EXT:news
+ * (`tx_news_domain_model_news.content_elements`): the same `tt_content` table is used both for
+ * normal content elements placed directly on a page and, in connected mode, as inline children of
+ * this record. The pointer column `tx_testinlinerelations_related` on `tt_content` is what tells
+ * the two apart - see the `tt_content` override in this extension.
+ *
+ * @see https://github.com/georgringer/news/blob/main/Configuration/TCA/tx_news_domain_model_news.php
+ */
+return [
+    'ctrl' => [
+        'title' => 'Inline content element parent',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'versioningWS' => true,
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'columns' => [
+        'title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'Content elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_field' => 'tx_testinlinerelations_related',
+                'foreign_sortby' => 'sorting',
+                'maxitems' => 99,
+                'appearance' => [
+                    'showSynchronizationLink' => true,
+                    'showAllLocalizationLink' => true,
+                    'showPossibleLocalizationRecords' => true,
+                    'expandSingle' => true,
+                    'enabledControls' => [
+                        'localize' => true,
+                    ],
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'title, content_elements, --div--;meta, hidden, sys_language_uid, l10n_parent',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_l10nsource.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_l10nsource.php
@@ -1,0 +1,73 @@
+<?php
+
+// A translatable table that declares a translation source field (l10n_source), used to reproduce
+// the TYPO3 Core defect forge #110281: BackendUtility::getRecordLocalization() / the DataHandler
+// localization guard match translations by l10n_source and miss a translation whose l10n_source is
+// empty, so DataHandler::localize() creates a duplicate translation.
+return [
+    'ctrl' => [
+        'title' => 'Test l10n_source translation lookup',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'sortby' => 'sorting',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'types' => [
+        '1' => [
+            'showitem' => 'title,hidden,sys_language_uid,l10n_parent',
+        ],
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => ['type' => 'language'],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => true,
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'default' => 0,
+            ],
+        ],
+        'title' => [
+            'exclude' => false,
+            'label' => 'Title',
+            'l10n_mode' => 'prefixLangTitle',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'eval' => 'trim',
+                'required' => true,
+            ],
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_parent.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_parent.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Inline (IRRE) parent record, mirroring the TCA reported in
+ * https://github.com/web-vision/deepltranslate-core/issues/503
+ */
+return [
+    'ctrl' => [
+        'title' => 'Inline relation parent',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'versioningWS' => true,
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'columns' => [
+        'title' => [
+            'exclude' => true,
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+        'children_declared' => [
+            'exclude' => true,
+            'label' => 'Children (pointer field configured in TCA)',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_testinlinerelations_child_declared',
+                'foreign_field' => 'parentid',
+                'foreign_sortby' => 'sorting',
+                'appearance' => [
+                    'showSynchronizationLink' => true,
+                    'showAllLocalizationLink' => true,
+                    'showPossibleLocalizationRecords' => true,
+                    'expandSingle' => true,
+                    'enabledControls' => [
+                        'localize' => true,
+                    ],
+                ],
+            ],
+        ],
+        'children_undeclared' => [
+            'exclude' => true,
+            'label' => 'Children (pointer field not configured in TCA)',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_testinlinerelations_child_undeclared',
+                'foreign_field' => 'parentid',
+                'foreign_sortby' => 'sorting',
+                'appearance' => [
+                    'showSynchronizationLink' => true,
+                    'showAllLocalizationLink' => true,
+                    'showPossibleLocalizationRecords' => true,
+                    'expandSingle' => true,
+                    'enabledControls' => [
+                        'localize' => true,
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'title, children_declared, children_undeclared, --div--;meta, hidden, sys_language_uid, l10n_parent',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_parent.php
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/Configuration/TCA/tx_testinlinerelations_parent.php
@@ -74,10 +74,26 @@ return [
                 ],
             ],
         ],
+        // Second field owning the same child table through a different pointer column, so a child
+        // record carrying both pointers is claimed by two parent relations at once - an ambiguous,
+        // broken configuration the resolver must refuse rather than guess.
+        'children_declared_ambiguous' => [
+            'exclude' => true,
+            'label' => 'Children (ambiguous second relation to the declared child table)',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_testinlinerelations_child_declared',
+                'foreign_field' => 'parentid_ambiguous',
+                'foreign_sortby' => 'sorting',
+                'appearance' => [
+                    'expandSingle' => true,
+                ],
+            ],
+        ],
     ],
     'types' => [
         '0' => [
-            'showitem' => 'title, children_declared, children_undeclared, --div--;meta, hidden, sys_language_uid, l10n_parent',
+            'showitem' => 'title, children_declared, children_undeclared, children_declared_ambiguous, --div--;meta, hidden, sys_language_uid, l10n_parent',
         ],
     ],
 ];

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/composer.json
@@ -1,0 +1,21 @@
+{
+	"name": "web-vision/test-inline-relations",
+	"type": "typo3-cms-extension",
+	"description": "Testing extension providing inline (IRRE) parent/child tables with foreign_field relations",
+	"license": [
+		"GPL-2.0-or-later"
+	],
+	"require": {
+		"typo3/cms-core": "*",
+		"web-vision/deepltranslate-core": "*"
+	},
+	"extra":{
+		"typo3/cms": {
+			"extension-key": "test_inline_relations",
+			"Package": {
+				"providesPackages": []
+			}
+		}
+	},
+	"version": "1.0.0-dev"
+}

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
@@ -5,16 +5,35 @@
 CREATE TABLE tx_testinlinerelations_parent (
     title varchar(255) DEFAULT '' NOT NULL,
     children_declared int(11) DEFAULT '0' NOT NULL,
-    children_undeclared int(11) DEFAULT '0' NOT NULL
+    children_undeclared int(11) DEFAULT '0' NOT NULL,
+    children_declared_ambiguous int(11) DEFAULT '0' NOT NULL
+);
+
+#
+# Parent embedding shared `tt_content` records, modelled on EXT:news `content_elements`.
+#
+CREATE TABLE tx_testinlinerelations_contentparent (
+    title varchar(255) DEFAULT '' NOT NULL,
+    content_elements int(11) DEFAULT '0' NOT NULL
+);
+
+#
+# Pointer column back to `tx_testinlinerelations_contentparent`, declared as `passthrough` in the
+# `tt_content` TCA override (mirrors EXT:news `tx_news_related_news`).
+#
+CREATE TABLE tt_content (
+    tx_testinlinerelations_related int(11) DEFAULT '0' NOT NULL
 );
 
 #
 # `parentid` of `tx_testinlinerelations_child_declared` is configured as `type => passthrough` in
 # TCA, which requires a manual column definition, see EXT:styleguide for the same pattern.
+# `parentid_ambiguous` is a second such pointer used only to construct an ambiguous relation.
 #
 CREATE TABLE tx_testinlinerelations_child_declared (
     title varchar(255) DEFAULT '' NOT NULL,
-    parentid int(11) DEFAULT '0' NOT NULL
+    parentid int(11) DEFAULT '0' NOT NULL,
+    parentid_ambiguous int(11) DEFAULT '0' NOT NULL
 );
 
 #

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
@@ -45,3 +45,13 @@ CREATE TABLE tx_testinlinerelations_child_undeclared (
     title varchar(255) DEFAULT '' NOT NULL,
     parentid int(11) DEFAULT '0' NOT NULL
 );
+
+#
+# Table declaring a `translationSource` (l10n_source), used to reproduce the TYPO3 Core
+# empty-l10n_source lookup defect (forge #110281). `l10n_source` is a `type => passthrough` column
+# and is therefore declared explicitly here.
+#
+CREATE TABLE tx_testinlinerelations_l10nsource (
+    title varchar(255) DEFAULT '' NOT NULL,
+    l10n_source int(11) DEFAULT '0' NOT NULL
+);

--- a/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/test_inline_relations/ext_tables.sql
@@ -1,0 +1,28 @@
+#
+# All columns are defined explicitly, because TYPO3 v12 only enriches tables already known from
+# `ext_tables.sql` and does not create them from TCA alone.
+#
+CREATE TABLE tx_testinlinerelations_parent (
+    title varchar(255) DEFAULT '' NOT NULL,
+    children_declared int(11) DEFAULT '0' NOT NULL,
+    children_undeclared int(11) DEFAULT '0' NOT NULL
+);
+
+#
+# `parentid` of `tx_testinlinerelations_child_declared` is configured as `type => passthrough` in
+# TCA, which requires a manual column definition, see EXT:styleguide for the same pattern.
+#
+CREATE TABLE tx_testinlinerelations_child_declared (
+    title varchar(255) DEFAULT '' NOT NULL,
+    parentid int(11) DEFAULT '0' NOT NULL
+);
+
+#
+# `parentid` of `tx_testinlinerelations_child_undeclared` is intentionally *not* configured in TCA
+# at all - which is the common real-world setup for a pure `foreign_field` pointer column and the
+# exact setup reported in https://github.com/web-vision/deepltranslate-core/issues/503.
+#
+CREATE TABLE tx_testinlinerelations_child_undeclared (
+    title varchar(255) DEFAULT '' NOT NULL,
+    parentid int(11) DEFAULT '0' NOT NULL
+);

--- a/Tests/Functional/Regression/EmptyL10nSourceCoreRegressionTest.php
+++ b/Tests/Functional/Regression/EmptyL10nSourceCoreRegressionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Tests\Functional\Regression;
+
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * Regression guard for the TYPO3 Core defect forge #110281, found while working on issue #503.
+ *
+ * ``BackendUtility::getRecordLocalization()`` (and, on TYPO3 v14,
+ * ``LocalizationRepository::getRecordTranslation()``) matches existing translations by the
+ * ``translationSource`` field (``l10n_source``) when the table declares one, and does not fall back
+ * to ``transOrigPointerField`` (``l10n_parent``). A valid translation with a correct ``l10n_parent``
+ * but an empty ``l10n_source`` - the usual result of a plain DataHandler datamap, an importer, a
+ * migration or MASK - is therefore invisible. ``DataHandler::localize()``, which the
+ * ``deepltranslate`` command is, uses that lookup to detect existing translations, so it does not
+ * see the translation and creates a **second** one in the same language.
+ *
+ * This is the root cause of the duplicated translations reported in
+ * web-vision/deepltranslate-auto-renew#42. It cannot be fixed inside this extension; the fix is in
+ * the TYPO3 Core (forge #110281, Gerrit 94914/94915/94916) and is applied for these test runs as a
+ * ``require-dev`` Composer patch on ``typo3/cms-backend`` (see the ``patches/`` directory and
+ * ``Documentation/CorePatches``). Without that patch this test fails.
+ *
+ * @see https://forge.typo3.org/issues/110281
+ * @see https://github.com/web-vision/deepltranslate-auto-renew/issues/42
+ */
+final class EmptyL10nSourceCoreRegressionTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+                'deeplAllowedAutoTranslate' => false,
+                'deeplAllowedReTranslate' => false,
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+                'deeplAllowedAutoTranslate' => true,
+                'deeplAllowedReTranslate' => true,
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->testExtensionsToLoad[] = __DIR__ . '/../Fixtures/Extensions/test_inline_relations';
+
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/l10nSourceEmpty.csv');
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                additionalRootConfiguration: [
+                    'deeplAllowedAutoTranslate' => true,
+                    'deeplAllowedReTranslate' => true,
+                ],
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER']);
+    }
+
+    /**
+     * The default record (uid 1) already has a German translation (uid 2) whose l10n_source is
+     * empty. Localizing it again to German must not create a duplicate - the existing translation
+     * has to be recognised.
+     */
+    #[Test]
+    public function localizingARecordWithAnEmptyL10nSourceTranslationCreatesNoDuplicate(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], [
+            'tx_testinlinerelations_l10nsource' => [
+                1 => [
+                    'deepltranslate' => 1,
+                ],
+            ],
+        ]);
+        $dataHandler->process_cmdmap();
+
+        // Exactly the default record and its single German translation - not a second one. Without
+        // the Core fix the existing translation is invisible to DataHandler::localize() and a
+        // duplicate is created (three records). With the fix the existing translation is found and
+        // reused, so the record count stays at two.
+        static::assertSame(2, $this->countRecords('tx_testinlinerelations_l10nsource'));
+    }
+
+    private function countRecords(string $table): int
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from($table)
+            ->executeQuery()
+            ->fetchOne();
+    }
+}

--- a/Tests/Functional/Regression/Fixtures/Results/inlineContentElementChildLocalized.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineContentElementChildLocalized.csv
@@ -1,0 +1,5 @@
+tt_content
+,"uid","pid","sys_language_uid","l18n_parent","l10n_source","tx_testinlinerelations_related","header"
+,10,1,0,0,0,1,"proton beam"
+,20,1,0,0,0,0,"proton beam"
+,21,1,1,10,10,2,"Protonenstrahl"

--- a/Tests/Functional/Regression/Fixtures/Results/inlineContentElementPageCeLocalized.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineContentElementPageCeLocalized.csv
@@ -1,0 +1,5 @@
+tt_content
+,"uid","pid","sys_language_uid","l18n_parent","l10n_source","tx_testinlinerelations_related","header"
+,10,1,0,0,0,1,"proton beam"
+,20,1,0,0,0,0,"proton beam"
+,21,1,1,20,20,0,"Protonenstrahl"

--- a/Tests/Functional/Regression/Fixtures/Results/inlineRelationsChildDeclaredLocalized.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineRelationsChildDeclaredLocalized.csv
@@ -1,0 +1,6 @@
+tx_testinlinerelations_child_declared
+,"uid","pid","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,0,0,0,1,"proton beam"
+,2,1,1,1,1,2,"Protonenstrahl"
+,3,1,0,0,0,1,"proton beam"
+,4,1,1,3,3,2,"Protonenstrahl"

--- a/Tests/Functional/Regression/Fixtures/Results/inlineRelationsChildUndeclaredLocalized.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineRelationsChildUndeclaredLocalized.csv
@@ -1,0 +1,6 @@
+tx_testinlinerelations_child_undeclared
+,"uid","pid","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,0,0,0,1,"proton beam"
+,2,1,1,1,1,2,"Protonenstrahl"
+,3,1,0,0,0,1,"proton beam"
+,4,1,1,3,3,2,"Protonenstrahl"

--- a/Tests/Functional/Regression/Fixtures/Results/inlineRelationsParentLocalized.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineRelationsParentLocalized.csv
@@ -1,0 +1,16 @@
+tx_testinlinerelations_parent
+,"uid","pid","sys_language_uid","l10n_parent","l10n_source","title"
+,1,1,0,0,0,"proton beam"
+,2,1,1,1,1,"Protonenstrahl"
+tx_testinlinerelations_child_declared
+,"uid","pid","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,0,0,0,1,"proton beam"
+,2,1,0,0,0,1,"proton beam"
+,3,1,1,1,1,2,"Protonenstrahl"
+,4,1,1,2,2,2,"Protonenstrahl"
+tx_testinlinerelations_child_undeclared
+,"uid","pid","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,0,0,0,1,"proton beam"
+,2,1,0,0,0,1,"proton beam"
+,3,1,1,1,1,2,"Protonenstrahl"
+,4,1,1,2,2,2,"Protonenstrahl"

--- a/Tests/Functional/Regression/Fixtures/Results/inlineRelationsUntranslatedParentUnchanged.csv
+++ b/Tests/Functional/Regression/Fixtures/Results/inlineRelationsUntranslatedParentUnchanged.csv
@@ -1,0 +1,7 @@
+tx_testinlinerelations_parent
+,"uid","pid","sys_language_uid","l10n_parent","title"
+,1,1,0,0,"proton beam"
+tx_testinlinerelations_child_declared
+,"uid","pid","sys_language_uid","l10n_parent","parentid","title"
+,1,1,0,0,1,"proton beam"
+,2,1,0,0,1,"proton beam"

--- a/Tests/Functional/Regression/Fixtures/inlineContentElementLocalize.csv
+++ b/Tests/Functional/Regression/Fixtures/inlineContentElementLocalize.csv
@@ -1,0 +1,11 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_contentparent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","content_elements"
+,1,1,256,0,0,0,"proton beam",1
+,2,1,256,1,1,1,"Protonenstrahl",0
+tt_content
+,"uid","pid","sorting","sys_language_uid","l18n_parent","l10n_source","CType","colPos","header","tx_testinlinerelations_related"
+,10,1,256,0,0,0,"textmedia",0,"proton beam",1
+,20,1,512,0,0,0,"textmedia",0,"proton beam",0

--- a/Tests/Functional/Regression/Fixtures/inlineRelationsBrokenChild.csv
+++ b/Tests/Functional/Regression/Fixtures/inlineRelationsBrokenChild.csv
@@ -1,0 +1,11 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_parent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","children_declared","children_undeclared"
+,1,1,256,0,0,0,"proton beam",1,0
+,2,1,256,1,1,1,"Protonenstrahl",0,0
+tx_testinlinerelations_child_declared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","parentid_ambiguous","title"
+,5,1,256,0,0,0,1,1,"proton beam"
+,6,1,512,0,0,0,99,0,"proton beam"

--- a/Tests/Functional/Regression/Fixtures/inlineRelationsChildLocalize.csv
+++ b/Tests/Functional/Regression/Fixtures/inlineRelationsChildLocalize.csv
@@ -1,0 +1,17 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_parent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","children_declared","children_undeclared"
+,1,1,256,0,0,0,"proton beam",2,2
+,2,1,256,1,1,1,"Protonenstrahl",1,1
+tx_testinlinerelations_child_declared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"
+,2,1,256,1,1,1,2,"Protonenstrahl"
+,3,1,512,0,0,0,1,"proton beam"
+tx_testinlinerelations_child_undeclared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"
+,2,1,256,1,1,1,2,"Protonenstrahl"
+,3,1,512,0,0,0,1,"proton beam"

--- a/Tests/Functional/Regression/Fixtures/inlineRelationsParentLocalize.csv
+++ b/Tests/Functional/Regression/Fixtures/inlineRelationsParentLocalize.csv
@@ -1,0 +1,14 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_parent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","children_declared","children_undeclared"
+,1,1,256,0,0,0,"proton beam",2,2
+tx_testinlinerelations_child_declared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"
+,2,1,512,0,0,0,1,"proton beam"
+tx_testinlinerelations_child_undeclared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"
+,2,1,512,0,0,0,1,"proton beam"

--- a/Tests/Functional/Regression/Fixtures/l10nSourceEmpty.csv
+++ b/Tests/Functional/Regression/Fixtures/l10nSourceEmpty.csv
@@ -1,0 +1,7 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_l10nsource
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title"
+,1,1,256,0,0,0,"proton beam"
+,2,1,256,1,1,0,"Protonenstrahl"

--- a/Tests/Functional/Regression/InlineChildForeignFieldRegressionTest.php
+++ b/Tests/Functional/Regression/InlineChildForeignFieldRegressionTest.php
@@ -166,6 +166,38 @@ final class InlineChildForeignFieldRegressionTest extends AbstractDeepLTestCase
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineRelationsUntranslatedParentUnchanged.csv');
     }
 
+    /**
+     * Issue #503 review follow-up: a child whose inline relation cannot be resolved reliably - here
+     * a record claimed by two parent relations at once - must be skipped and reported, not silently
+     * localized into a mis-attached translation.
+     *
+     * @test
+     */
+    public function translatingChildWithAmbiguousInlineRelationCreatesNoTranslation(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsBrokenChild.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_child_declared', 5, 1);
+
+        // Only the two default-language records from the fixture, no translation was created.
+        static::assertSame(2, $this->countRecords('tx_testinlinerelations_child_declared'));
+    }
+
+    /**
+     * Issue #503 review follow-up: a child pointing at a parent record that does not exist is broken
+     * data - it must be skipped and reported, not localized on its own.
+     *
+     * @test
+     */
+    public function translatingChildPointingToMissingParentCreatesNoTranslation(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsBrokenChild.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_child_declared', 6, 1);
+
+        static::assertSame(2, $this->countRecords('tx_testinlinerelations_child_declared'));
+    }
+
     private function dispatchDeeplTranslateCommand(string $table, int $uid, int $targetLanguageId): void
     {
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);

--- a/Tests/Functional/Regression/InlineChildForeignFieldRegressionTest.php
+++ b/Tests/Functional/Regression/InlineChildForeignFieldRegressionTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Tests\Functional\Regression;
+
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * Regression tests for https://github.com/web-vision/deepltranslate-core/issues/503
+ *
+ * The `deepltranslate` command is a plain `DataHandler::localize()` call. Localizing an inline
+ * parent record works, because TYPO3 fills `DataHandler::$registerDBList` and finally repairs the
+ * `foreign_field` pointer of the localized children through
+ * `DataHandler::remapListedDBRecords_procInline()` -> `RelationHandler::writeForeignField()`.
+ *
+ * Dispatching the command for an inline *child* record - which is what
+ * `web-vision/deepltranslate-auto-renew` does for a newly added child - never fills
+ * `$registerDBList`, therefore the `foreign_field` pointer is never written and the translated
+ * child stays orphaned.
+ */
+final class InlineChildForeignFieldRegressionTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    /**
+     * @var non-empty-string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepltranslate-core',
+        __DIR__ . '/../Fixtures/Extensions/test_services_override',
+        __DIR__ . '/../Fixtures/Extensions/test_inline_relations',
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+                'deeplAllowedAutoTranslate' => false,
+                'deeplAllowedReTranslate' => false,
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+                'deeplAllowedAutoTranslate' => true,
+                'deeplAllowedReTranslate' => true,
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                additionalRootConfiguration: [
+                    'deeplAllowedAutoTranslate' => true,
+                    'deeplAllowedReTranslate' => true,
+                ],
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER']);
+    }
+
+    /**
+     * Control test / regression guard: dispatching the command on the inline **parent** record
+     * localizes all children and attaches them to the translated parent. This is core behaviour
+     * and expected to work.
+     *
+     * @test
+     */
+    public function translatingInlineParentAttachesLocalizedChildrenToTranslatedParent(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsParentLocalize.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_parent', 1, 1);
+
+        static::assertSame(2, $this->countRecords('tx_testinlinerelations_parent'));
+        static::assertSame(4, $this->countRecords('tx_testinlinerelations_child_declared'));
+        static::assertSame(4, $this->countRecords('tx_testinlinerelations_child_undeclared'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineRelationsParentLocalized.csv');
+    }
+
+    /**
+     * Issue #503: dispatching the command for the inline **child** record itself must attach the
+     * created translation to the already existing translated parent record.
+     *
+     * The `foreign_field` pointer column is configured as `type => passthrough` in TCA here, so
+     * `DataHandler::copyRecord()` takes the value over unchanged - which leaves the translated
+     * child pointing to the *default language* parent instead of the translated one.
+     *
+     * @test
+     */
+    public function translatingInlineChildWithTcaConfiguredPointerFieldAttachesTranslationToTranslatedParent(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsChildLocalize.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_child_declared', 3, 1);
+
+        static::assertSame(4, $this->countRecords('tx_testinlinerelations_child_declared'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineRelationsChildDeclaredLocalized.csv');
+    }
+
+    /**
+     * Issue #503, same as above but with the `foreign_field` pointer column *not* configured in
+     * TCA at all - the setup used in the issue report. `DataHandler::fillInFieldArray()` drops
+     * values of columns unknown to the TCA schema, so the translated child ends up with an empty
+     * pointer field.
+     *
+     * @test
+     */
+    public function translatingInlineChildWithoutTcaConfiguredPointerFieldAttachesTranslationToTranslatedParent(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsChildLocalize.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_child_undeclared', 3, 1);
+
+        static::assertSame(4, $this->countRecords('tx_testinlinerelations_child_undeclared'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineRelationsChildUndeclaredLocalized.csv');
+    }
+
+    /**
+     * Issue #503: without a translated parent record a child translation cannot be attached to anything.
+     * Nothing must be created in that case, mirroring `DataHandler::inlineLocalizeSynchronize()`.
+     *
+     * @test
+     */
+    public function translatingInlineChildWithoutTranslatedParentCreatesNoOrphanedTranslation(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelationsParentLocalize.csv');
+
+        $this->dispatchDeeplTranslateCommand('tx_testinlinerelations_child_declared', 1, 1);
+
+        static::assertSame(1, $this->countRecords('tx_testinlinerelations_parent'));
+        static::assertSame(2, $this->countRecords('tx_testinlinerelations_child_declared'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineRelationsUntranslatedParentUnchanged.csv');
+    }
+
+    private function dispatchDeeplTranslateCommand(string $table, int $uid, int $targetLanguageId): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], [
+            $table => [
+                $uid => [
+                    'deepltranslate' => $targetLanguageId,
+                ],
+            ],
+        ]);
+        $dataHandler->process_cmdmap();
+
+        static::assertSame([], $dataHandler->errorLog);
+    }
+
+    private function countRecords(string $table): int
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from($table)
+            ->executeQuery()
+            ->fetchOne();
+    }
+}

--- a/Tests/Functional/Regression/InlineContentElementForeignFieldRegressionTest.php
+++ b/Tests/Functional/Regression/InlineContentElementForeignFieldRegressionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Tests\Functional\Regression;
+
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
+
+/**
+ * Real-world regression tests for https://github.com/web-vision/deepltranslate-core/issues/503 using
+ * the shared `tt_content` table as the inline child, the way EXT:news embeds content elements into
+ * `tx_news_domain_model_news.content_elements`.
+ *
+ * The point of these tests is the reliable distinction, raised in review, between the two roles a
+ * `tt_content` record can have:
+ *
+ * - a genuine inline child of another record - it must be localized through its parent so the
+ *   `foreign_field` pointer (`tx_testinlinerelations_related`) is written to the translated parent;
+ * - a normal content element placed directly on a page - it must keep being localized on its own,
+ *   exactly as before, and must not be routed through a non-existing parent.
+ */
+final class InlineContentElementForeignFieldRegressionTest extends AbstractDeepLTestCase
+{
+    use SiteBasedTestTrait;
+
+    /**
+     * @var non-empty-string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepltranslate-core',
+        __DIR__ . '/../Fixtures/Extensions/test_services_override',
+        __DIR__ . '/../Fixtures/Extensions/test_inline_relations',
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => [
+            'id' => 0,
+            'title' => 'English',
+            'locale' => 'en_US.UTF-8',
+            'iso' => 'en',
+            'hrefLang' => 'en-US',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => '',
+                'deeplAllowedAutoTranslate' => false,
+                'deeplAllowedReTranslate' => false,
+            ],
+        ],
+        'DE' => [
+            'id' => 1,
+            'title' => 'Deutsch',
+            'locale' => 'de_DE',
+            'iso' => 'de',
+            'hrefLang' => 'de-DE',
+            'direction' => '',
+            'custom' => [
+                'deeplTargetLanguage' => 'DE',
+                'deeplAllowedAutoTranslate' => true,
+                'deeplAllowedReTranslate' => true,
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineContentElementLocalize.csv');
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                additionalRootConfiguration: [
+                    'deeplAllowedAutoTranslate' => true,
+                    'deeplAllowedReTranslate' => true,
+                ],
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration('EN', '/'),
+                $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'strict'),
+            ],
+        );
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER']);
+    }
+
+    /**
+     * Issue #503 for the real-world `tt_content` case: a content element used as an inline child of
+     * another record (`tx_testinlinerelations_related` set) is localized through its parent, so the
+     * pointer of the created translation targets the *translated* parent record.
+     *
+     * @test
+     */
+    public function translatingContentElementUsedAsInlineChildAttachesTranslationToTranslatedParent(): void
+    {
+        $this->dispatchDeeplTranslateCommand('tt_content', 10, 1);
+
+        static::assertSame(3, $this->countRecords('tt_content'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineContentElementChildLocalized.csv');
+    }
+
+    /**
+     * The counterpart: a `tt_content` element placed directly on a page (no inline parent) must keep
+     * being localized normally - a translation of the element itself, with the pointer column left
+     * untouched. It must not be treated as an inline child.
+     *
+     * @test
+     */
+    public function translatingContentElementOnPageLocalizesItNormally(): void
+    {
+        $this->dispatchDeeplTranslateCommand('tt_content', 20, 1);
+
+        static::assertSame(3, $this->countRecords('tt_content'));
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/inlineContentElementPageCeLocalized.csv');
+    }
+
+    private function dispatchDeeplTranslateCommand(string $table, int $uid, int $targetLanguageId): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], [
+            $table => [
+                $uid => [
+                    'deepltranslate' => $targetLanguageId,
+                ],
+            ],
+        ]);
+        $dataHandler->process_cmdmap();
+
+        static::assertSame([], $dataHandler->errorLog);
+    }
+
+    private function countRecords(string $table): int
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder
+            ->count('uid')
+            ->from($table)
+            ->executeQuery()
+            ->fetchOne();
+    }
+}

--- a/Tests/Functional/Service/Fixtures/inlineRelations.csv
+++ b/Tests/Functional/Service/Fixtures/inlineRelations.csv
@@ -1,0 +1,14 @@
+pages
+,"uid","pid","title","sys_language_uid","slug"
+,1,0,"Deepl-Functional-Test",0,"/"
+tx_testinlinerelations_parent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","children_declared","children_undeclared"
+,1,1,256,0,0,0,"proton beam",1,1
+tx_testinlinerelations_child_declared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"
+,2,1,512,0,0,0,0,"orphaned child"
+,3,1,768,0,0,0,99,"child of a non existing parent"
+tx_testinlinerelations_child_undeclared
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
+,1,1,256,0,0,0,1,"proton beam"

--- a/Tests/Functional/Service/Fixtures/inlineRelations.csv
+++ b/Tests/Functional/Service/Fixtures/inlineRelations.csv
@@ -4,11 +4,19 @@ pages
 tx_testinlinerelations_parent
 ,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","children_declared","children_undeclared"
 ,1,1,256,0,0,0,"proton beam",1,1
+tx_testinlinerelations_contentparent
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","title","content_elements"
+,1,1,256,0,0,0,"proton beam",1
 tx_testinlinerelations_child_declared
-,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
-,1,1,256,0,0,0,1,"proton beam"
-,2,1,512,0,0,0,0,"orphaned child"
-,3,1,768,0,0,0,99,"child of a non existing parent"
+,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","parentid_ambiguous","title"
+,1,1,256,0,0,0,1,0,"proton beam"
+,2,1,512,0,0,0,0,0,"orphaned child"
+,3,1,768,0,0,0,99,0,"child of a non existing parent"
+,4,1,1024,0,0,0,1,1,"child claimed by two parent relations"
 tx_testinlinerelations_child_undeclared
 ,"uid","pid","sorting","sys_language_uid","l10n_parent","l10n_source","parentid","title"
 ,1,1,256,0,0,0,1,"proton beam"
+tt_content
+,"uid","pid","sorting","sys_language_uid","l18n_parent","l10n_source","CType","colPos","header","tx_testinlinerelations_related"
+,10,1,256,0,0,0,"textmedia",0,"proton beam",1
+,20,1,512,0,0,0,"textmedia",0,"proton beam",0

--- a/Tests/Functional/Service/InlineRelationResolverTest.php
+++ b/Tests/Functional/Service/InlineRelationResolverTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Tests\Functional\Service;
+
+use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
+use WebVision\Deepltranslate\Core\Service\InlineRelationResolver;
+use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
+
+final class InlineRelationResolverTest extends AbstractDeepLTestCase
+{
+    /**
+     * @var non-empty-string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
+        'web-vision/deepltranslate-core',
+        __DIR__ . '/../Fixtures/Extensions/test_services_override',
+        __DIR__ . '/../Fixtures/Extensions/test_inline_relations',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/inlineRelations.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function inlineChildWithTcaConfiguredPointerFieldIsResolved(): void
+    {
+        $reference = $this->get(InlineRelationResolver::class)
+            ->resolveParentReference('tx_testinlinerelations_child_declared', 1);
+
+        static::assertInstanceOf(InlineParentReference::class, $reference);
+        static::assertSame('tx_testinlinerelations_child_declared', $reference->childTable);
+        static::assertSame(1, $reference->childUid);
+        static::assertSame('tx_testinlinerelations_parent', $reference->parentTable);
+        static::assertSame('children_declared', $reference->parentField);
+        static::assertSame(1, $reference->parentUid);
+        static::assertSame('parentid', $reference->foreignField);
+    }
+
+    /**
+     * @test
+     */
+    public function inlineChildWithoutTcaConfiguredPointerFieldIsResolved(): void
+    {
+        $reference = $this->get(InlineRelationResolver::class)
+            ->resolveParentReference('tx_testinlinerelations_child_undeclared', 1);
+
+        static::assertInstanceOf(InlineParentReference::class, $reference);
+        static::assertSame('tx_testinlinerelations_parent', $reference->parentTable);
+        static::assertSame('children_undeclared', $reference->parentField);
+        static::assertSame(1, $reference->parentUid);
+    }
+
+    /**
+     * @test
+     */
+    public function recordWhichIsNoInlineChildIsNotResolved(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_parent', 1));
+        static::assertNull($resolver->resolveParentReference('pages', 1));
+    }
+
+    /**
+     * @test
+     */
+    public function inlineChildWithoutPointerValueIsNotResolved(): void
+    {
+        static::assertNull(
+            $this->get(InlineRelationResolver::class)
+                ->resolveParentReference('tx_testinlinerelations_child_declared', 2)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function inlineChildPointingToNonExistingParentIsNotResolved(): void
+    {
+        static::assertNull(
+            $this->get(InlineRelationResolver::class)
+                ->resolveParentReference('tx_testinlinerelations_child_declared', 3)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function nonExistingRecordIsNotResolved(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_child_declared', 99));
+        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_child_declared', 0));
+        static::assertNull($resolver->resolveParentReference('table_which_does_not_exist', 1));
+    }
+}

--- a/Tests/Functional/Service/InlineRelationResolverTest.php
+++ b/Tests/Functional/Service/InlineRelationResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Tests\Functional\Service;
 
 use WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference;
+use WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState;
 use WebVision\Deepltranslate\Core\Service\InlineRelationResolver;
 use WebVision\Deepltranslate\Core\Tests\Functional\AbstractDeepLTestCase;
 
@@ -37,6 +38,10 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
 
         static::assertTrue($resolver->isPossibleInlineChildTable('tx_testinlinerelations_child_declared'));
         static::assertTrue($resolver->isPossibleInlineChildTable('tx_testinlinerelations_child_undeclared'));
+        // Shared table: `tt_content` is a normal content element on a page, but is also usable as an
+        // inline child - here through `tx_testinlinerelations_contentparent.content_elements`, the
+        // same shape EXT:news uses for `tx_news_domain_model_news.content_elements`.
+        static::assertTrue($resolver->isPossibleInlineChildTable('tt_content'));
         // Shipped by TYPO3 itself, for example through `tt_content.image`
         static::assertTrue($resolver->isPossibleInlineChildTable('sys_file_reference'));
     }
@@ -49,6 +54,7 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
         $resolver = $this->get(InlineRelationResolver::class);
 
         static::assertFalse($resolver->isPossibleInlineChildTable('tx_testinlinerelations_parent'));
+        static::assertFalse($resolver->isPossibleInlineChildTable('tx_testinlinerelations_contentparent'));
         static::assertFalse($resolver->isPossibleInlineChildTable('pages'));
         static::assertFalse($resolver->isPossibleInlineChildTable('table_which_does_not_exist'));
     }
@@ -58,9 +64,11 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
      */
     public function inlineChildWithTcaConfiguredPointerFieldIsResolved(): void
     {
-        $reference = $this->get(InlineRelationResolver::class)
+        $resolution = $this->get(InlineRelationResolver::class)
             ->resolveParentReference('tx_testinlinerelations_child_declared', 1);
 
+        static::assertSame(InlineParentState::Resolved, $resolution->state);
+        $reference = $resolution->reference;
         static::assertInstanceOf(InlineParentReference::class, $reference);
         static::assertSame('tx_testinlinerelations_child_declared', $reference->childTable);
         static::assertSame(1, $reference->childUid);
@@ -75,9 +83,11 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
      */
     public function inlineChildWithoutTcaConfiguredPointerFieldIsResolved(): void
     {
-        $reference = $this->get(InlineRelationResolver::class)
+        $resolution = $this->get(InlineRelationResolver::class)
             ->resolveParentReference('tx_testinlinerelations_child_undeclared', 1);
 
+        static::assertSame(InlineParentState::Resolved, $resolution->state);
+        $reference = $resolution->reference;
         static::assertInstanceOf(InlineParentReference::class, $reference);
         static::assertSame('tx_testinlinerelations_parent', $reference->parentTable);
         static::assertSame('children_undeclared', $reference->parentField);
@@ -85,47 +95,112 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
     }
 
     /**
+     * The real-world case behind issue #503: `tt_content` used as an inline child (like EXT:news
+     * `content_elements`) must resolve to its owning record.
+     *
      * @test
      */
-    public function recordWhichIsNoInlineChildIsNotResolved(): void
+    public function sharedTableRecordUsedAsInlineChildIsResolved(): void
     {
-        $resolver = $this->get(InlineRelationResolver::class);
+        $resolution = $this->get(InlineRelationResolver::class)
+            ->resolveParentReference('tt_content', 10);
 
-        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_parent', 1));
-        static::assertNull($resolver->resolveParentReference('pages', 1));
+        static::assertSame(InlineParentState::Resolved, $resolution->state);
+        $reference = $resolution->reference;
+        static::assertInstanceOf(InlineParentReference::class, $reference);
+        static::assertSame('tt_content', $reference->childTable);
+        static::assertSame('tx_testinlinerelations_contentparent', $reference->parentTable);
+        static::assertSame('content_elements', $reference->parentField);
+        static::assertSame(1, $reference->parentUid);
+        static::assertSame('tx_testinlinerelations_related', $reference->foreignField);
+    }
+
+    /**
+     * The counterpart: a `tt_content` element placed directly on a page shares its table with inline
+     * children but is not one, and must be treated as a normal record - not routed through a parent.
+     *
+     * @test
+     */
+    public function sharedTableRecordNotUsedAsInlineChildIsNotInlineChild(): void
+    {
+        $resolution = $this->get(InlineRelationResolver::class)
+            ->resolveParentReference('tt_content', 20);
+
+        static::assertSame(InlineParentState::NotInlineChild, $resolution->state);
+        static::assertNull($resolution->reference);
     }
 
     /**
      * @test
      */
-    public function inlineChildWithoutPointerValueIsNotResolved(): void
+    public function recordWhichIsNoInlineChildIsNotInlineChild(): void
     {
-        static::assertNull(
-            $this->get(InlineRelationResolver::class)
-                ->resolveParentReference('tx_testinlinerelations_child_declared', 2)
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        static::assertSame(
+            InlineParentState::NotInlineChild,
+            $resolver->resolveParentReference('tx_testinlinerelations_parent', 1)->state
+        );
+        static::assertSame(
+            InlineParentState::NotInlineChild,
+            $resolver->resolveParentReference('pages', 1)->state
         );
     }
 
     /**
      * @test
      */
-    public function inlineChildPointingToNonExistingParentIsNotResolved(): void
+    public function inlineChildWithoutPointerValueIsNotInlineChild(): void
     {
-        static::assertNull(
+        static::assertSame(
+            InlineParentState::NotInlineChild,
             $this->get(InlineRelationResolver::class)
-                ->resolveParentReference('tx_testinlinerelations_child_declared', 3)
+                ->resolveParentReference('tx_testinlinerelations_child_declared', 2)->state
         );
     }
 
     /**
      * @test
      */
-    public function nonExistingRecordIsNotResolved(): void
+    public function inlineChildPointingToNonExistingParentReportsParentMissing(): void
+    {
+        static::assertSame(
+            InlineParentState::ParentMissing,
+            $this->get(InlineRelationResolver::class)
+                ->resolveParentReference('tx_testinlinerelations_child_declared', 3)->state
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function childClaimedByTwoParentRelationsReportsAmbiguous(): void
+    {
+        static::assertSame(
+            InlineParentState::Ambiguous,
+            $this->get(InlineRelationResolver::class)
+                ->resolveParentReference('tx_testinlinerelations_child_declared', 4)->state
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function nonExistingRecordIsNotInlineChild(): void
     {
         $resolver = $this->get(InlineRelationResolver::class);
 
-        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_child_declared', 99));
-        static::assertNull($resolver->resolveParentReference('tx_testinlinerelations_child_declared', 0));
-        static::assertNull($resolver->resolveParentReference('table_which_does_not_exist', 1));
+        static::assertSame(
+            InlineParentState::NotInlineChild,
+            $resolver->resolveParentReference('tx_testinlinerelations_child_declared', 99)->state
+        );
+        static::assertSame(
+            InlineParentState::NotInlineChild,
+            $resolver->resolveParentReference('tx_testinlinerelations_child_declared', 0)->state
+        );
+        static::assertSame(
+            InlineParentState::NotInlineChild,
+            $resolver->resolveParentReference('table_which_does_not_exist', 1)->state
+        );
     }
 }

--- a/Tests/Functional/Service/InlineRelationResolverTest.php
+++ b/Tests/Functional/Service/InlineRelationResolverTest.php
@@ -31,6 +31,31 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
     /**
      * @test
      */
+    public function tablesUsableAsInlineChildAreDetectedWithoutARecord(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        static::assertTrue($resolver->isPossibleInlineChildTable('tx_testinlinerelations_child_declared'));
+        static::assertTrue($resolver->isPossibleInlineChildTable('tx_testinlinerelations_child_undeclared'));
+        // Shipped by TYPO3 itself, for example through `tt_content.image`
+        static::assertTrue($resolver->isPossibleInlineChildTable('sys_file_reference'));
+    }
+
+    /**
+     * @test
+     */
+    public function tablesNotUsableAsInlineChildAreNotDetected(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        static::assertFalse($resolver->isPossibleInlineChildTable('tx_testinlinerelations_parent'));
+        static::assertFalse($resolver->isPossibleInlineChildTable('pages'));
+        static::assertFalse($resolver->isPossibleInlineChildTable('table_which_does_not_exist'));
+    }
+
+    /**
+     * @test
+     */
     public function inlineChildWithTcaConfiguredPointerFieldIsResolved(): void
     {
         $reference = $this->get(InlineRelationResolver::class)

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true,
 			"helhum/typo3-console-plugin": true,
-			"php-http/discovery": true
+			"php-http/discovery": true,
+			"vaimo/composer-patches": true
 		}
 	},
 	"extra": {
@@ -70,6 +71,18 @@
 		},
 		"branch-alias": {
 			"dev-main": "5.x.x-dev"
+		},
+		"patches": {
+			"typo3/cms-backend": {
+				"TYPO3 Core #110281 (find translations with empty l10n_source) on TYPO3 v12.4 ELTS - never fixed upstream, always patched": {
+					"source": "Build/patches/typo3-cms-backend-110281-v12-v13.patch",
+					"version": ">=12.4.0 <13.0.0"
+				},
+				"TYPO3 Core #110281 (find translations with empty l10n_source) on TYPO3 v13.4 - TEMPORARY until the fix ships in the next patch level release": {
+					"source": "Build/patches/typo3-cms-backend-110281-v12-v13.patch",
+					"version": ">=13.4.0 <13.4.34"
+				}
+			}
 		}
 	},
 	"require": {
@@ -111,7 +124,8 @@
 		"typo3/cms-styleguide": "^12.0.5 || ^13.4",
 		"typo3/cms-tstemplate": "^12.4.2 || ^13.4",
 		"typo3/cms-workspaces": "^12.4.2 || ^13.4",
-		"typo3/testing-framework": "^8.3.1"
+		"typo3/testing-framework": "^8.3.1",
+		"vaimo/composer-patches": "^6.0.1"
 	},
 	"suggest": {
         "b13/container": "Just to be loaded after EXT:container",


### PR DESCRIPTION
Backport of #598 to the `5` branch (TYPO3 **12.4 + 13.4**, PHP **8.1**+). Tracked as **DPL-193**.
Fixes the `foreign_field` part of #503 for the 5.x line.

See #598 for the full problem description and analysis. This PR is **not a plain cherry-pick** and
**requires its own review and votes** because of the deviations listed below.

## Differences to the `main` change (#598)

1. **Resolver backing** - `InlineRelationResolver` resolves relations on the plain `$GLOBALS['TCA']`
   array instead of the TCA schema API (`TcaSchemaFactory`), which does not exist in TYPO3 v12.
2. **No `RecordLocalizationResolver` split** - `BackendUtility::getRecordLocalization()` is not
   deprecated in v12/v13 and is used directly; there is no v14 `LocalizationRepository::getRecordTranslation()`
   path on this branch.
3. **Logging backend** - the "parent has no translation yet" case **and** the broken-relation cases
   (`Ambiguous`, `ParentMissing`) are logged through the extension logger (`LogManager`) instead of
   `DataHandler::log()`, whose signature is **incompatible** between v12 and v13 (`$recpid` is
   `int|string` in v12 but `null` in v13; `$details_nr` is `int` in v12 but `null` in v13) - no
   argument satisfies both.
4. **Injection** - `InlineRelationResolver` is injected through `#[Required]` setter injection
   instead of the constructor, to avoid changing the `AbstractTranslateHook` constructor signature
   within a maintenance branch.
5. **`readonly`** - `InlineParentReference` and `InlineParentResolution` keep **per-property**
   `readonly`, because PHP 8.1 has no `readonly class`; `main` uses `readonly class`.
6. **Fixture SQL** - the fixture extension declares **every table and column explicitly** in
   `ext_tables.sql` (including the `tt_content` pointer column and the ambiguous second pointer),
   because TYPO3 v12 only enriches tables already known from SQL and does not create them from TCA
   alone. `main` trims this to only the columns v13/v14 cannot derive from TCA.
7. **Test style** - tests use the `@test` annotation and `static::assert*`, matching the existing
   suite on this branch (instead of `#[Test]` / `$this->assert*` on `main`).
8. **No changelog** - there is no `Documentation/Changelog/` directory on this branch, so no
   changelog entries are added.

Everything else is identical to #598: the resolution logic, the `InlineParentResolution` /
`InlineParentState` states (`Resolved`, `NotInlineChild`, `Ambiguous`, `ParentMissing`), the routing
through `inlineLocalizeSynchronize`, `isPossibleInlineChildTable()`, and the full test set - the
child-declared / child-undeclared pointer variants, the `tt_content` / EXT:news real-world case
(genuine inline child attached to the translated parent vs. page content element localized
normally), and the ambiguous / missing-parent skip cases.

## Outcome / verification

`Build/Scripts/runTests.sh` on **TYPO3 12.4 and 13.4**, both **sqlite and MariaDB**, PHP 8.2:
`cgl`, `lintPhp`, `checkExceptionCodes`, `phpstan` (Core12 + Core13), `unit`, `functional` - all
green on both core versions. CI is green across the full matrix (core 12 on PHP 8.1 / 8.4, core 13
on PHP 8.2 / 8.5).

The child-driven bug tests were verified to **fail** before the fix, with the same symptom as on
`main`.
