### PR TITLE
[TASK] Raise 'web-vision/deeplcom-deepl-php' to '1.19.0'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,8 +96,8 @@
         "typo3/cms-extbase": "~13.4.28@dev || ~14.3.0@dev",
         "typo3/cms-fluid": "~13.4.28@dev || ~14.3.0@dev",
         "typo3/cms-install": "~13.4.28@dev || ~14.3.0@dev",
-        "web-vision/deepl-base": "^2.0.1@dev",
-        "web-vision/deeplcom-deepl-php": "~1.18.0@dev"
+        "web-vision/deepl-base": "^2.0.5@dev",
+        "web-vision/deeplcom-deepl-php": "~1.19.0@dev"
     },
     "require-dev": {
         "b13/container": "^3.2.2",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,8 +17,8 @@ $EM_CONF[$_EXTKEY] = [
             'extbase' => '13.4.0-14.3.99',
             'fluid' => '13.4.0-14.3.99',
             'install' => '13.4.0-14.3.99',
-            'deeplcom_deeplphp' => '1.18.0-1.18.99',
-            'deepl_base' => '2.0.1-2.99.99',
+            'deeplcom_deeplphp' => '1.19.0-1.19.99',
+            'deepl_base' => '2.0.5-2.99.99',
         ],
         'conflicts' => [
             'recordlist_thumbnail' => '',


### PR DESCRIPTION
## Why

The bundled DeepL PHP library 1.19.0 provides the `/v3/languages` and
`/v3/languages/resources` endpoints (`getLanguagesForResource()` /
`getLanguageResources()`), which are required to query glossary
language support through the v3 API instead of the deprecated
`/v2/glossary-language-pairs` endpoint.

The previous constraint `~1.18.0@dev` resolves to `>=1.18.0 <1.19.0`
and therefore excluded that release.

## What

```shell
composer require --no-update \
  "web-vision/deeplcom-deepl-php:~1.19.0@dev" \
  "web-vision/deepl-base":"^2.0.5@dev"
```

## Merge order

Depends on web-vision/deeplcom-deepl-php#22. That pull request only
prepares `1.19.0-dev`; the constraint here cannot resolve until the
`1.19.0` tag of `web-vision/deeplcom-deepl-php` is actually released.
Release the library extension first, then merge this one.