### PR TITLE
[TASK] Raise 'web-vision/deeplcom-deepl-php' to '1.19.0' (5.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,8 @@
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4",
-		"web-vision/deepl-base": "^1.0.4@dev",
-		"web-vision/deeplcom-deepl-php": "^1.16.1"
+		"web-vision/deepl-base": "^1.0.7@dev",
+		"web-vision/deeplcom-deepl-php": "~1.19.0@dev"
 	},
 	"require-dev": {
 		"b13/container": "^2.3.6 || ^3.2.2",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,8 +17,8 @@ $EM_CONF[$_EXTKEY] = [
             'extbase' => '12.4.0-13.4.99',
             'fluid' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
-            'deepl_base' => '1.0.4-1.99.99',
-            'deeplcom_deeplphp' => '1.16.1-1.99.99',
+            'deepl_base' => '1.0.7-1.99.99',
+            'deeplcom_deeplphp' => '1.19.0-1.19.99',
         ],
         'conflicts' => [
             'recordlist_thumbnail' => '*',


### PR DESCRIPTION
## Why

The previous constraint `^1.16.1` floats across the whole remaining
1.x range, so this branch silently picks up every future library
release. Aligning it with the pinning style used on the main branch
keeps the maintenance branch on a defined library version.

`deeplcom/deepl-php` 1.19.0 migrates the request bodies of
`/v2/translate`, `/v2/glossaries` and `/v2/write/rephrase` to
`application/json` with retyped fields. Those are exactly the code
paths this branch uses, so the raise has been verified rather than
assumed.

## What

```shell
composer require --no-update \
  "web-vision/deeplcom-deepl-php:~1.19.0@dev" \
  "web-vision/deepl-base":"^1.0.7@dev"
```

## Verification

Full suite run locally against `deeplcom/deepl-php` v1.19.0, on both
supported core versions:

| Suite | TYPO3 12 | TYPO3 13.4.33 |
| --- | --- | --- |
| unit | 14 tests, 71 assertions — OK | 14 tests, 71 assertions — OK |
| functional (sqlite, mock server) | 45 tests, 109 assertions — OK | 45 tests, 109 assertions — OK |
| phpstan | no errors | no errors |

No code changes were needed for the reworked JSON request bodies.

## Merge order

Depends on web-vision/deeplcom-deepl-php#22. That pull request only
prepares `1.19.0-dev`; `~1.19.0@dev` cannot resolve until the `1.19.0`
tag of `web-vision/deeplcom-deepl-php` is released. Release the library
extension first, then merge this one.

## Notes for reviewers

- `VERSION` intentionally stays at `5.1.7-dev` — this is a dependency
  raise, not a release.
- The roof development setup forces `web-vision/deeplcom-deepl-php` to
  `1.x-dev` in its path repository options, which no longer satisfies
  `~1.19.0@dev`. That mapping needs updating for local monorepo work.
