### PR TITLE
[BUGFIX] Alias this branch instead of a non existing one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
 			"version": "5.1.8-dev"
 		},
 		"branch-alias": {
-			"dev-main": "5.x.x-dev"
+			"dev-5": "5.1.x-dev"
 		},
 		"patches": {
 			"typo3/cms-backend": {


### PR DESCRIPTION
## Problem

`extra.branch-alias` on this branch declares **`dev-main`**:

```json
"branch-alias": {
    "dev-main": "5.x.x-dev"
}
```

There is no `main` branch here, so the alias never applies. The branches `4` and
`3.0` declare `dev-4` / `dev-3.0` correctly - this branch is the odd one out.

As a consequence Packagist exposes this branch only as `5.x-dev`, which
normalizes to `5.9999999.9999999-dev` - **above** the `< 5.2.0` upper bound of a
`~5.1.x` constraint. Requiring the branch for an unreleased patch level therefore
fails:

```
Root composer.json requires web-vision/deepltranslate-core ~5.1.8@dev,
found web-vision/deepltranslate-core[..., 5.x-dev] but it does not match the constraint.
```

That blocks depending extensions from testing against this branch before the next
patch level release is tagged.

## Fix

Alias the branch that actually exists and pin it to the minor line it provides,
matching the `6.0.x-dev` form used on the main branch:

```json
"branch-alias": {
    "dev-5": "5.1.x-dev"
}
```

`~5.1.8@dev` then resolves to this branch, and to the tag once released.

Metadata only - no runtime impact. Verified locally: composerUpdate, cgl, unit and
functional (TYPO3 v12, sqlite) all pass.