### PR TITLE
[BUGFIX] Use the derived version as branch alias key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
 			"version": "5.1.8-dev"
 		},
 		"branch-alias": {
-			"dev-5": "5.1.x-dev"
+			"5.x-dev": "5.1.x-dev"
 		},
 		"patches": {
 			"typo3/cms-backend": {


### PR DESCRIPTION
Follow-up to #608, which did not achieve what it claimed - my mistake.

## Problem

#608 changed the alias key from `dev-main` to `dev-5`. Both are ignored: Composer
derives the version of a **numeric** branch from the branch name, so this branch
is `5.x-dev`, and `extra.branch-alias` must be keyed by that derived version
string. Composer's resolver output shows it plainly - `main` is aliased, this
branch is not:

```
6.0.x-dev (alias of dev-main)     <- main, alias applied
5.x-dev                            <- this branch, no alias
```

`5.x-dev` normalizes to `5.9999999.9999999-dev`, above the `< 5.2.0` bound of
`~5.1.x`, so depending extensions still cannot require this branch before the
next patch level is tagged.

## Fix

```diff
-    "dev-5": "5.1.x-dev"
+    "5.x-dev": "5.1.x-dev"
```

## Verification

A/B tested against Composer 2 with a local VCS repository serving this branch and
a probe project requiring `~5.1.8@dev`:

*   key `dev-5` -> `Your requirements could not be resolved ... found [..., 5.x-dev] but it does not match the constraint`
*   key `5.x-dev` -> `Locking web-vision/deepltranslate-core (5.x-dev)`

Locally: composerUpdate (v12), cgl and unit pass.

## Note

The branches `4` and `3.0` carry the same inert pattern (`dev-4` / `dev-3.0`).
Not touched here; worth correcting separately if those lines still receive
dependency testing.