### PR TITLE
[TASK] Run CI containers with docker

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,15 @@
 name: documentation
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
 
@@ -27,7 +37,7 @@ jobs:
           comment-author: 'github-actions[bot]'
 
       - name: "Render documentation"
-        run: "Build/Scripts/runTests.sh -b podman -s renderDocumentation"
+        run: "Build/Scripts/runTests.sh -b docker -s renderDocumentation"
 
       - uses: actions/upload-artifact@v6
         id: documentation-artifact

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -1,5 +1,15 @@
 name: tests core 13
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
   workflow_dispatch:
@@ -17,34 +27,34 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Validate composer.json"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock"
 
       - name: "Run TypoScript lint"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s lintTypoScript"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkBom"
 
 #      - name: "Test .rst files for integrity"
-#        run: "Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php-version }} -s checkRst"
+#        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v13
@@ -59,25 +69,25 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v13"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Unit"
-        run: "Build/Scripts/runTests.sh -b podman -b podman -t 13 -p ${{ matrix.php-version }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s unit"
 
       - name: "Functional SQLite"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b podman -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -1,5 +1,15 @@
 name: tests core 14
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   pull_request:
   workflow_dispatch:
@@ -17,34 +27,34 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v14"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Validate composer.json"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s composer -- validate --strict --no-check-lock"
 
       - name: "Run TypoScript lint"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s lintTypoScript"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s lintTypoScript"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"
 
       - name: "Ensure UTF-8 files do not contain BOM"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s checkBom"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s checkBom"
 
 #      - name: "Test .rst files for integrity"
-#        run: "Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php-version }} -s checkRst"
+#        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s checkRst"
 
       - name: "Find duplicate exception codes"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s checkExceptionCodes"
 
       - name: "Run PHPStan"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s phpstan"
 
   testsuite:
     name: all tests with core v14
@@ -59,25 +69,25 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v14"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Unit"
-        run: "Build/Scripts/runTests.sh -b podman -b podman -t 14 -p ${{ matrix.php-version }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s unit"
 
       - name: "Functional SQLite"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d sqlite"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b podman -t 14 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -566,7 +566,13 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
+                # "mode=1777" is required for docker and harmless for podman: docker runs
+                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
+                # up owned by root with mode 0755, so the test databases cannot be created
+                # and every test fails with "unable to open database file". Rootless podman
+                # passes no "--user" (it is root inside its user namespace), which is why
+                # this only shows with docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;
@@ -584,7 +590,7 @@ case ${TEST_SUITE} in
         ;;
     renderDocumentation)
         # ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project -it ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-log --fail-on-error --no-progress --config=Documentation Documentation
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project -it ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)


### PR DESCRIPTION
## Why

GitHub hosted runners ship both podman and docker. Since 2026-07-29 their
podman/crun combination intermittently aborts the **first container start of a
job** with

```
Error: OCI runtime error: crun: unknown version specified
```

exit code 126. It is independent of the job, the core version and the PHP
version, and a rerun on another host clears it. Neither the runner image nor
the TYPO3 testing image changed, so this is variance in the GitHub host fleet,
not in anything of ours.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever it is present and only
falls back to docker. That default is correct for the script — podman-only
machines are exactly what it is built for — so it stays. The GitHub hosted
runners are the single place these workflows meet the broken combination, so
the override belongs in the workflows.

Every `runTests.sh` call now passes `-b docker`, with the reasoning in the
workflow header so the flag can be dropped knowingly once GitHub stops
producing the mismatch.

## Selecting docker exposed a second, unrelated defect

docker runs the container as `--user $HOST_UID` with group 0, while the sqlite
tmpfs comes up owned by `root:root` with mode `0755` — so no test database can
be created and every functional sqlite test fails with `unable to open database
file`. Rootless podman is root inside its user namespace and passes no
`--user`, which is why this never showed before.

Fixed in `runTests.sh` by mounting that tmpfs with `mode=1777`: docker needs
it, podman does not mind, and it stays correct regardless of which runtime is
selected.

## Documentation rendering

That job pinned `-b podman` explicitly. It moves to `-b docker` too, which
required dropping a redundant hardcoded `-it` from the `renderDocumentation`
container run: docker rejects `-t` without a TTY (`the input device is not a
TTY`), and the script already manages the interactive flags itself
(`CONTAINER_INTERACTIVE`, empty in CI). Local runs keep `-it --init`.

## This pull request is its own proof

The pipeline below runs with both changes.
