### PR TITLE
[BUGFIX] Wait longer for database readiness

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -10,10 +10,13 @@ fi
 waitFor() {
     local HOST=${1}
     local PORT=${2}
+    # 60 rather than 10 seconds: mysql:8.0 needs 12-13s under docker to
+    # initialise a fresh data directory, about twice as long as under podman,
+    # so an 11 second budget aborted the functional mysql suites at random.
     local TESTCOMMAND="
         COUNT=0;
         while ! nc -z ${HOST} ${PORT}; do
-            if [ \"\${COUNT}\" -gt 10 ]; then
+            if [ \"\${COUNT}\" -gt 60 ]; then
               echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
               exit 1;
             fi;
@@ -23,7 +26,11 @@ waitFor() {
     "
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} /bin/sh -c "${TESTCOMMAND}"
     if [[ $? -gt 0 ]]; then
-        kill -SIGINT -$$
+        # Not "kill -SIGINT -$$": the SIGINT trap is only installed when CI is
+        # not "true", so in CI the signal was a no-op, the run continued and the
+        # test suite connected to a database that was not listening.
+        cleanUp
+        exit 1
     fi
 }
 


### PR DESCRIPTION
## Why

`waitFor()` capped the readiness poll at 11 iterations of `sleep 1` — about 11
seconds. Measured against the same images, time from `run -d` until the port
accepts connections:

| image | podman | docker |
|---|---|---|
| `mysql:8.0` | 7.0–7.2 s | **12.2–13.2 s** |
| `mariadb:10.4` | 7.8 s | 8.2 s |
| `postgres:10` | 1.3 s | 1.5 s |

Only mysql crosses the limit, and only under docker, whose entrypoint needs
about twice as long to initialise a fresh data directory. Since the workflows
now select docker, the functional mysql suites started aborting intermittently.
The cap is 60 s instead, which also gives mariadb a sensible margin.

## The abort did not abort

`kill -SIGINT -$$` relies on the SIGINT trap, and that trap is only installed
when `CI` is not `"true"`. In CI the kill was a no-op, so the script carried on
and ran the test suite against a database that was not listening — reporting
dozens of `Connection refused` errors instead of the readiness timeout that had
actually happened. `waitFor()` now cleans up and exits directly.
