### PR TITLE
[BUGFIX] Localize child of untranslatable parent

### DIFF
--- a/Classes/Domain/Dto/InlineParentResolution.php
+++ b/Classes/Domain/Dto/InlineParentResolution.php
@@ -12,7 +12,9 @@ use WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState;
  *
  * The state lets the caller tell a normal standalone record ({@see InlineParentState::NotInlineChild},
  * silent) apart from a broken relation configuration ({@see InlineParentState::Ambiguous},
- * {@see InlineParentState::ParentMissing}, worth reporting to the editor).
+ * {@see InlineParentState::ParentMissing}, worth reporting to the editor) and from an inline
+ * child whose parent table cannot be translated at all
+ * ({@see InlineParentState::ParentNotTranslatable}, silent, localized on its own).
  */
 final class InlineParentResolution
 {
@@ -40,6 +42,11 @@ final class InlineParentResolution
     public static function parentMissing(): self
     {
         return new self(InlineParentState::ParentMissing);
+    }
+
+    public static function parentNotTranslatable(): self
+    {
+        return new self(InlineParentState::ParentNotTranslatable);
     }
 
     public function isResolved(): bool

--- a/Classes/Domain/Enum/InlineParentState.php
+++ b/Classes/Domain/Enum/InlineParentState.php
@@ -33,5 +33,14 @@ enum InlineParentState
     /**
      * The record is an inline child in connected mode and its parent was resolved unambiguously.
      */
+    /**
+     * The record is an inline child in connected mode, but the parent table itself is not
+     * translatable - most prominently `sys_file_metadata`, which is owned by the
+     * non-translatable `sys_file`. There can never be a parent localization to attach the
+     * child to, so the child has to be localized on its own instead of being handed over to
+     * the DataHandler command dealing with inline children.
+     */
+    case ParentNotTranslatable;
+
     case Resolved;
 }

--- a/Classes/Service/InlineRelationResolver.php
+++ b/Classes/Service/InlineRelationResolver.php
@@ -70,6 +70,7 @@ final class InlineRelationResolver
 
         $references = [];
         $parentMissing = false;
+        $parentNotTranslatable = false;
         foreach ($this->getInlineParentCandidates($childTable) as $candidate) {
             $parentTable = $candidate['parentTable'];
             $configuration = $candidate['configuration'];
@@ -77,6 +78,19 @@ final class InlineRelationResolver
             if ($parentUid === null) {
                 // The record is not attached to this parent field (pointer empty, or a table/match
                 // field discriminator excludes it) - not an inline child through this candidate.
+                continue;
+            }
+            $parentCtrl = $GLOBALS['TCA'][$parentTable]['ctrl'] ?? [];
+            if (!isset($parentCtrl['languageField'], $parentCtrl['transOrigPointerField'])) {
+                // `sys_file` owns `sys_file_metadata` through a `foreign_field` pointer, but
+                // `sys_file` itself is not translatable. There can never be a parent localization
+                // to attach the child to, so handing the localization over to
+                // `DataHandler::inlineLocalizeSynchronize()` would create nothing at all. Such a
+                // child is localized on its own instead. Checked before looking the parent record
+                // up: it saves a query and keeps a non-translatable parent from being reported as
+                // a missing one. Mirrors `TcaSchema::isLanguageAware()` of TYPO3 v13, which is not
+                // available on v12.
+                $parentNotTranslatable = true;
                 continue;
             }
             if (!is_array(BackendUtility::getRecord($parentTable, $parentUid))) {
@@ -102,6 +116,11 @@ final class InlineRelationResolver
         }
         if (count($references) === 1) {
             return InlineParentResolution::resolved(array_pop($references));
+        }
+        if ($parentNotTranslatable) {
+            // Takes precedence over `$parentMissing`: if the parent table cannot be translated at
+            // all, the hand-over never applies and a dangling pointer is not worth reporting.
+            return InlineParentResolution::parentNotTranslatable();
         }
         if ($parentMissing) {
             return InlineParentResolution::parentMissing();

--- a/Tests/Functional/Service/Fixtures/inlineRelations.csv
+++ b/Tests/Functional/Service/Fixtures/inlineRelations.csv
@@ -20,3 +20,9 @@ tt_content
 ,"uid","pid","sorting","sys_language_uid","l18n_parent","l10n_source","CType","colPos","header","tx_testinlinerelations_related"
 ,10,1,256,0,0,0,"textmedia",0,"proton beam",1
 ,20,1,512,0,0,0,"textmedia",0,"proton beam",0
+sys_file
+,"uid","pid","storage","identifier","identifier_hash","folder_hash","extension","mime_type","name","sha1","size","type"
+,1,0,1,"/proton-beam.jpg","1111111111111111111111111111111111111111","2222222222222222222222222222222222222222","jpg","image/jpeg","proton-beam.jpg","3333333333333333333333333333333333333333",1024,2
+sys_file_metadata
+,"uid","pid","sys_language_uid","l10n_parent","file","title","description","alternative"
+,1,0,0,0,1,"proton beam","proton beam description","proton beam alternative"

--- a/Tests/Functional/Service/InlineRelationResolverTest.php
+++ b/Tests/Functional/Service/InlineRelationResolverTest.php
@@ -203,4 +203,36 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
             $resolver->resolveParentReference('table_which_does_not_exist', 1)->state
         );
     }
+
+    /**
+     * @test
+     */
+    public function inlineChildOfANonTranslatableParentIsNotHandedOverToTheParent(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        // `sys_file` owns `sys_file_metadata` through a `foreign_field` pointer, so the metadata
+        // record really is an inline child in connected mode - but `sys_file` itself has no
+        // `languageField`/`transOrigPointerField` and can never carry a localization. Handing the
+        // localization over to the parent would create nothing at all, so such a child has to be
+        // reported as `ParentNotTranslatable` and localized on its own.
+        $resolution = $resolver->resolveParentReference('sys_file_metadata', 1);
+
+        static::assertSame(InlineParentState::ParentNotTranslatable, $resolution->state);
+        static::assertNull($resolution->reference);
+        static::assertFalse($resolution->isResolved());
+    }
+
+    /**
+     * @test
+     */
+    public function tableOwnedByANonTranslatableParentIsStillAPossibleInlineChildTable(): void
+    {
+        $resolver = $this->get(InlineRelationResolver::class);
+
+        // Unchanged behaviour: the table-level check only answers whether records of that table can
+        // be inline children at all. Whether the concrete parent is translatable is decided per
+        // record in `resolveParentReference()`.
+        static::assertTrue($resolver->isPossibleInlineChildTable('sys_file_metadata'));
+    }
 }


### PR DESCRIPTION
Fixes #618.

## The defect

`sys_file` declares `sys_file_metadata` as a connected mode inline child through a
`foreign_field` pointer, but `sys_file` itself has neither `languageField` nor
`transOrigPointerField` and can never carry a localization.

`InlineRelationResolver` only checked that a candidate parent field points at the
child table, carries no `MM` and has a non-empty `foreign_field`. It never asked
whether the parent table can be translated at all. So since 6.0.4 / 5.1.7 metadata
records were classified as inline children, their localization was handed over to
`DataHandler::inlineLocalizeSynchronize()` on the parent, and — as
`AbstractTranslateHook::localizeInlineChildRecord()` documents — a parent without
localization creates nothing. Translating file metadata silently produced nothing.

## The fix

A new state `InlineParentState::ParentNotTranslatable`, reported when the resolved
parent table is not translatable. It carries no reference and is not a broken
relation, so `AbstractTranslateHook` falls through to the regular localization and
the child is localized on its own again — the behaviour before the inline relation
resolution was introduced. **The hook needed no change**; the fall-through is
already the shape of that code.

The check is placed before the parent record lookup: it saves a query, and it keeps
a non-translatable parent from being reported as a missing one. It also takes
precedence over `ParentMissing`, on the grounds that a hand-over which can never
apply makes a dangling pointer not worth reporting to the editor.

Detecting whether a table can be an inline child *at all*
(`isPossibleInlineChildTable()`) is deliberately unchanged — `sys_file_metadata`
genuinely can be an inline child. Only the per-record resolution gained the
distinction.

This does not weaken the #503 fix: a connected mode inline child of a
*translatable* parent is still handed over, which is what #503 was about.

## Implementation note per branch

* `main` (TYPO3 13.4 + 14.3) uses core's purpose-built `TcaSchema::isLanguageAware()`.
* `5` (TYPO3 12.4 + 13.4) cannot — there is no `TcaSchemaFactory` on v12 — so it
  mirrors the same predicate on `ctrl` directly
  (`isset($ctrl['languageField'], $ctrl['transOrigPointerField'])`), which is
  exactly what `isLanguageAware()` evaluates.

## Verification

Two functional tests added, using the real `sys_file` / `sys_file_metadata` pair
rather than a synthetic fixture.

Each line was verified with a negative control — with the guard removed, the new
test fails showing the resolver returning `Resolved` instead, i.e. exactly the
hand-over that creates nothing:

```
-InlineParentState Enum (ParentNotTranslatable)
+InlineParentState Enum (Resolved)
```

| line | functional | negative control | cgl | phpstan |
|---|---|---|---|---|
| `main`, v13/8.2 | OK (13 tests, 42 assertions) | fails as expected | pass | no errors |
| `5`, v12/8.1 | OK (13 tests, 42 assertions) | fails as expected | pass | no errors |

## Follow-up, not in this pull request

* `deepltranslate-assets` needs a **tagged** release to pick this up: it sets
  `prefer-stable: true`, so `~6.0.3@dev` keeps resolving the newest tag rather than
  `6.0.x-dev`. Its two open pull requests stay red until `6.0.6` / `5.1.9` exist.
* `Documentation/Changelog/6.0/Feature-InlineRelationResolver.rst` (6.0 line only)
  describes behaviour that was partly wrong and may deserve a companion note.
