### PR TITLE
[BUGFIX] Ignore untranslatable inline parents

### DIFF
--- a/Classes/Service/InlineRelationResolver.php
+++ b/Classes/Service/InlineRelationResolver.php
@@ -32,7 +32,13 @@ final class InlineRelationResolver
 
     /**
      * Whether any TCA field can own records of the given table through a `foreign_field` pointer
-     * column, meaning records of that table can be inline children in connected mode.
+     * column, meaning records of that table can be inline children in connected mode whose
+     * localization has to be handed over to their parent.
+     *
+     * Only parents which can carry a localization themselves count. A table owned exclusively by
+     * untranslatable parents - `sys_file_metadata`, owned by `sys_file` - is not reported, because
+     * the hand-over could never produce anything for it and such a child has to be localized on
+     * its own.
      *
      * In contrast to {@see self::resolveParentReference()} this does not need a record and can
      * therefore be used at points where the pointer column of a newly created child record has not
@@ -43,8 +49,10 @@ final class InlineRelationResolver
         if (!isset($GLOBALS['TCA'][$childTable])) {
             return false;
         }
-        foreach ($this->getInlineParentCandidates($childTable) as $ignored) {
-            return true;
+        foreach ($this->getInlineParentCandidates($childTable) as $candidate) {
+            if ($this->parentCanCarryLocalization($candidate['parentTable'])) {
+                return true;
+            }
         }
 
         return false;
@@ -80,8 +88,7 @@ final class InlineRelationResolver
                 // field discriminator excludes it) - not an inline child through this candidate.
                 continue;
             }
-            $parentCtrl = $GLOBALS['TCA'][$parentTable]['ctrl'] ?? [];
-            if (!isset($parentCtrl['languageField'], $parentCtrl['transOrigPointerField'])) {
+            if (!$this->parentCanCarryLocalization($parentTable)) {
                 // `sys_file` owns `sys_file_metadata` through a `foreign_field` pointer, but
                 // `sys_file` itself is not translatable. There can never be a parent localization
                 // to attach the child to, so handing the localization over to
@@ -127,6 +134,23 @@ final class InlineRelationResolver
         }
 
         return InlineParentResolution::notInlineChild();
+    }
+
+    /**
+     * Whether the given parent table can carry a localization at all, meaning a localized inline
+     * child could be attached to a translated parent record.
+     *
+     * `sys_file` is the prominent counter example: it owns `sys_file_metadata` through a
+     * `foreign_field` pointer, but has neither `languageField` nor `transOrigPointerField`, so a
+     * hand-over to `DataHandler::inlineLocalizeSynchronize()` could never produce anything.
+     *
+     * Mirrors `TcaSchema::isLanguageAware()` of TYPO3 v13, which is not available on v12.
+     */
+    private function parentCanCarryLocalization(string $parentTable): bool
+    {
+        $parentCtrl = $GLOBALS['TCA'][$parentTable]['ctrl'] ?? [];
+
+        return isset($parentCtrl['languageField'], $parentCtrl['transOrigPointerField']);
     }
 
     /**

--- a/Tests/Functional/Service/InlineRelationResolverTest.php
+++ b/Tests/Functional/Service/InlineRelationResolverTest.php
@@ -226,13 +226,17 @@ final class InlineRelationResolverTest extends AbstractDeepLTestCase
     /**
      * @test
      */
-    public function tableOwnedByANonTranslatableParentIsStillAPossibleInlineChildTable(): void
+    public function tableOwnedOnlyByANonTranslatableParentIsNotAPossibleInlineChildTable(): void
     {
         $resolver = $this->get(InlineRelationResolver::class);
 
-        // Unchanged behaviour: the table-level check only answers whether records of that table can
-        // be inline children at all. Whether the concrete parent is translatable is decided per
-        // record in `resolveParentReference()`.
-        static::assertTrue($resolver->isPossibleInlineChildTable('sys_file_metadata'));
+        // `sys_file_metadata` is owned by `sys_file` only, which cannot carry a localization, so the
+        // hand-over to the parent could never produce anything. Callers which have to decide before
+        // the pointer column of a new record is written - the DataHandler processing does - must be
+        // able to see that from the table alone.
+        static::assertFalse($resolver->isPossibleInlineChildTable('sys_file_metadata'));
+
+        // Counter check: a table owned by a translatable parent is still reported.
+        static::assertTrue($resolver->isPossibleInlineChildTable('sys_file_reference'));
     }
 }


### PR DESCRIPTION
Follow-up to #619 / #620 (issue #618). Those fixed the **per-record** resolution;
this fixes the **table-level** check, which is what the DataHandler callers actually
use. Both are needed — end-to-end verification showed the first fix alone leaves one
of the three broken cases still broken.

## Why the first fix was not enough

`deepltranslate-auto-renew` decides whether a record must be localized through its
parent at a point where a newly created inline child has **no `foreign_field` pointer
value yet**, so it cannot use `resolveParentReference()`. It uses the table-level
`isPossibleInlineChildTable()` instead — deliberately, and documented as such:

```php
// The check is table-level (`isPossibleInlineChildTable()`) on purpose: a newly created
// inline child has no `foreign_field` pointer value yet at this point, so a per-record
// resolution could not recognise it.
```

That check reported `sys_file_metadata` as an inline child regardless of whether the
owning table can be translated. So the record was deferred to the "localize through
the parent" path, `sys_file` can never carry a localization, and nothing was created —
even with `ParentNotTranslatable` in place for the per-record path.

## The change

`isPossibleInlineChildTable()` now counts only parents which can carry a localization
themselves. Both the table-level and the per-record check share one private predicate,
`parentCanCarryLocalization()`, so they cannot drift apart.

A table owned by at least one translatable parent is reported exactly as before —
`sys_file_reference` is asserted as a counter check in the tests.

This is a **behaviour change to a public method**. It is intentional: the method exists
solely to answer "must this record be localized through its parent instead of on its
own", and for a table owned only by untranslatable parents that answer was wrong.

## Verification

| line | full functional | unit | cgl | phpstan |
|---|---|---|---|---|
| `main`, v13/8.2 | OK (66 tests, 191 assertions) | OK (16 tests, 30) | pass | no errors |
| `5`, v12/8.1 | OK (67 tests, 199 assertions) | OK (14 tests, 71) | pass | no errors |

The full suites matter here rather than the single test file, because tightening a
public method could have broken other callers. Nothing else regressed.

End-to-end against `deepltranslate-assets`, with the released core as control:

| core | assets `main` | assets `2` |
|---|---|---|
| released (6.0.5 / 5.1.8) | 3 failures | 3 failures |
| #619 / #620 only | 1 failure | 1 failure |
| with this change | expected green | expected green |

The remaining single failure was `AutoTranslationTest::metadataIsAutoTranslated`, and a
probe of exactly this guard turned it green. Re-verification with the real commits is
running.

## Note

`deepltranslate-auto-renew` needs **no change** — both of its call sites become correct
through this fix, so no auto-renew release is required.
