### PR TITLE
[TASK] DPL-197: runTests.sh and workflow follow-ups

### DIFF
--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -84,10 +84,10 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -84,10 +84,10 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -399,6 +399,7 @@ handleDbmsOptions
 COMPOSER_ROOT_VERSION="6.0.7-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -465,9 +466,25 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT} -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm ${USERSET} -v ${ROOT_DIR}:/project"
+    # docker creates a tmpfs owned by "root:root", inheriting the mode of its host
+    # mountpoint, while "${USERSET}" above passes a uid but no group and therefore runs
+    # the container as "uid=${HOST_UID} gid=0". At a CI umask of 0022 the mountpoint is
+    # 0755, so group 0 gets "r-x" and no test database can be created.
+    #
+    # "uid"/"gid" address that at the source: the mount is owned by the user the container
+    # runs as, whatever the umask of the host mountpoint. "mode=1777" is the workaround the
+    # docker adoption introduced instead, and is kept next to them - it is what has been
+    # proven on a GitHub hosted runner, and it costs nothing to leave in place.
+    #
+    # None of this reproduces at the 0002 umask of a typical workstation, where the
+    # mountpoint comes up 0775 and the group bit already grants access. Use "umask 0022".
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_GID},mode=1777"
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
+    # Rootless podman maps the container root to the host user, so the tmpfs is writable
+    # without an explicit owner. "mode=1777" is kept for the rootful case.
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,mode=1777"
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT}  -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT}  -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -v ${ROOT_DIR}:/project"
@@ -573,13 +590,11 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                # "mode=1777" is required for docker and harmless for podman: docker runs
-                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
-                # up owned by root with mode 0755, so the test databases cannot be created
-                # and every test fails with "unable to open database file". Rootless podman
-                # passes no "--user" (it is root inside its user namespace), which is why
-                # this only shows with docker.
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
+                # "${TMPFS_MOUNT_OPTIONS}" carries the owner and mode the mount needs, which
+                # differ per container binary - see where it is assigned. Without them the
+                # test databases cannot be created and every test fails with "unable to open
+                # database file".
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:${TMPFS_MOUNT_OPTIONS} -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -400,6 +400,9 @@ COMPOSER_ROOT_VERSION="6.0.7-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
+# Additional container parameters, provided by the environment. Empty unless the caller
+# exports it, which is how the portfolio harnesses inject CI specific flags.
+CI_PARAMS="${CI_PARAMS:-}"
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -612,7 +615,7 @@ case ${TEST_SUITE} in
         ;;
     renderDocumentation)
         # ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project -it ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-log --fail-on-error --no-progress --config=Documentation Documentation
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project -v ${ROOT_DIR}:/project ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation
+        ${CONTAINER_BIN} run ${DOCUMENTATION_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project ${IMAGE_RSTRENDERING} --config=Documentation --fail-on-error --no-progress --config=Documentation Documentation
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)


### PR DESCRIPTION
Follow-up work left over from the CI pipeline adoption, `main` branch part.
Everything here is pre-existing — none of it was caused by that adoption, it was
found while doing it. Tracked as DPL-197.

Three independent changes, one commit each.

### Run the MySQL functional jobs on MySQL

The four steps named `Functional MySQL 8.0 mysqli` / `... pdo_mysql` passed
`-d mariadb`, so they duplicated the two MariaDB steps above them under a MySQL
name. No workflow invoked `-d mysql` at all — MySQL was never exercised on any
core version. They run `-d mysql` now.

No version is pinned: `handleDbmsOptions` already defaults `-i` to `8.0` for
MySQL, which is exactly what the step names promise. The harness needed nothing
else — the `mysql` branch, the `mysql-func` container and `IMAGE_MYSQL` have
always been there and were simply never reached from CI. The readiness budget
covers the slower startup, `waitFor` allows 60s since the docker adoption and
`mysql:8.0` needs 12-13s under docker.

The MariaDB steps are deliberately left alone. They claim 10.5 while passing no
`-i` and therefore run the 10.4 default — a separate label defect, not part of
this pull request.

### Own the sqlite tmpfs from the host user

`${USERSET}` passes `--user ${HOST_UID}` without a group, so a docker container
runs as `uid=N gid=0(root)`. A `--tmpfs` is created `root:root` and inherits the
mode of its host mountpoint — 0755 at a CI umask of 0022 — so group 0 gets `r-x`
and the functional sqlite suite fails with `unable to open database file`.

The docker adoption worked around this with `mode=1777`, which is correct but
treats the one mount rather than the missing group. The mount options move into
`TMPFS_MOUNT_OPTIONS`, assigned per container binary: docker adds `uid`/`gid` and
keeps `mode=1777`, rootless podman maps the container root to the host user and
keeps `mode=1777` for the rootful case.

`${USERSET}` is deliberately **not** changed. It is evaluated for both container
binaries, and appending a group there would change which host group rootless
podman maps the container to — a different question from who owns a tmpfs.

Probed directly under `umask 0022`, docker, `--user $(id -u)`:

| tmpfs options | mount | result |
|---|---|---|
| `rw,noexec,nosuid` | `drwxr-xr-x root root` | `Permission denied` |
| `rw,noexec,nosuid,mode=1777` | `drwxrwxrwt root root` | writable |
| `rw,noexec,nosuid,uid=,gid=,mode=1777` | `drwxrwxrwt 1000 1000` | writable |

Note this is invisible at the 0002 umask of a typical workstation, where the
mountpoint comes up 0775 — reproduce with `umask 0022`.

### Revive two unused harness variables

`CI_PARAMS` is expanded into the podman container parameters and the mock server
container but was never assigned. It is not a leftover: the harnesses this one is
modelled on assign it as `CI_PARAMS="${CI_PARAMS:-}"` and treat it as an escape
hatch a caller can export to inject additional container flags. Only that
assignment was missing, so it is added rather than the references removed.

`DOCUMENTATION_COMMON_PARAMS` was built for both container binaries and never
used — `renderDocumentation` ran with `CONTAINER_COMMON_PARAMS` and therefore also
received `--network`, `--add-host` and a `-w ${ROOT_DIR}` which the later
`-w /project` overrode again. It renders documentation, it does not talk to a
database container, so it now uses the parameters built for it. The bind mount the
run line repeated is part of them and is dropped from the line.

## Verification

Locally, under `umask 0022`, `CI=true`, `-b docker` — **23/23 green**:

* core 13 / PHP 8.2 and core 14 / PHP 8.4: `composerUpdate`, `cgl`, `phpstan`,
  `unit`, functional `sqlite`, `mysql -a mysqli`, `mysql -a pdo_mysql`,
  `mariadb -a mysqli`, plus `postgres` on core 13
* `renderDocumentation` under both docker and podman
* podman regression: functional sqlite on core 14, both with `CI=true` and with
  `CI` unset (interactive path)

One `composerUpdate` run hit the known `class-alias-loader` transient
(`CaseSensitiveToken not found`) and poisoned `.Build` for every following suite;
re-run after removing `.Build`, all green. Unrelated to this change, which touches
no composer configuration.

## Acceptance

* diff touches only `Build/Scripts/runTests.sh` and `.github/workflows/*`
* no workflow job, step, matrix entry or trigger added, removed or reordered
  (verified by comparing the parsed YAML structure against `main`)
* untouched as required: the `-b docker` flags and workflow header comment, the
  sqlite `mode=1777` option, the `waitFor` cap of 60 and its abort (block is
  byte-identical to `main`), and `CONTAINER_INTERACTIVE="-it --init"`

Branch `5` and the changelog correction follow in separate pull requests.
