### PR TITLE
[TASK] DPL-197: runTests.sh and workflow follow-ups

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -81,10 +81,10 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
         run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -81,10 +81,10 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
 
       - name: "Functional PostgresSQL 10"
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -397,6 +397,7 @@ handleDbmsOptions
 COMPOSER_ROOT_VERSION="5.1.10-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -463,9 +464,25 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT} -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm ${USERSET} -v ${ROOT_DIR}:/project"
+    # docker creates a tmpfs owned by "root:root", inheriting the mode of its host
+    # mountpoint, while "${USERSET}" above passes a uid but no group and therefore runs
+    # the container as "uid=${HOST_UID} gid=0". At a CI umask of 0022 the mountpoint is
+    # 0755, so group 0 gets "r-x" and no test database can be created.
+    #
+    # "uid"/"gid" address that at the source: the mount is owned by the user the container
+    # runs as, whatever the umask of the host mountpoint. "mode=1777" is the workaround the
+    # docker adoption introduced instead, and is kept next to them - it is what has been
+    # proven on a GitHub hosted runner, and it costs nothing to leave in place.
+    #
+    # None of this reproduces at the 0002 umask of a typical workstation, where the
+    # mountpoint comes up 0775 and the group bit already grants access. Use "umask 0022".
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_GID},mode=1777"
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
+    # Rootless podman maps the container root to the host user, so the tmpfs is writable
+    # without an explicit owner. "mode=1777" is kept for the rootful case.
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,mode=1777"
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT}  -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} ${DEEPL_BASE_MOUNT}  -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -v ${ROOT_DIR}:/project"
@@ -571,13 +588,11 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                # "mode=1777" is required for docker and harmless for podman: docker runs
-                # the container as "--user $HOST_UID" with group 0, while the tmpfs comes
-                # up owned by root with mode 0755, so the test databases cannot be created
-                # and every test fails with "unable to open database file". Rootless podman
-                # passes no "--user" (it is root inside its user namespace), which is why
-                # this only shows with docker.
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
+                # "${TMPFS_MOUNT_OPTIONS}" carries the owner and mode the mount needs, which
+                # differ per container binary - see where it is assigned. Without them the
+                # test databases cannot be created and every test fails with "unable to open
+                # database file".
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:${TMPFS_MOUNT_OPTIONS} -e DEEPL_API_KEY=mock_server -e DEEPL_HOST=deepl-func-${SUFFIX} -e DEEPL_PORT=3000 -e DEEPL_SERVER_URL=deepl-func-${SUFFIX}:3000 -e DEEPL_MOCK_SERVER_PORT=3000 -e DEEPL_SCHEME=http -e DEEPL_MOCKSERVER_USED=1"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -398,6 +398,9 @@ COMPOSER_ROOT_VERSION="5.1.10-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
+# Additional container parameters, provided by the environment. Empty unless the caller
+# exports it, which is how the portfolio harnesses inject CI specific flags.
+CI_PARAMS="${CI_PARAMS:-}"
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -609,7 +612,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     renderDocumentation)
-        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} --pull always -v ${ROOT_DIR}:/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
+        ${CONTAINER_BIN} run ${DOCUMENTATION_COMMON_PARAMS} --name rendering-documentation-${SUFFIX} --pull always -w /project ${IMAGE_DOCS} --config=Documentation
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)


### PR DESCRIPTION
Follow-up work left over from the CI pipeline adoption, `5` branch part.
Everything here is pre-existing — none of it was caused by that adoption, it was
found while doing it. Tracked as DPL-197. Counterpart of #627 on `main`.

Two of the three commits match `main`; the third covers a defect `main` did not
have, because the docker adoption already fixed it there.

### Run the MySQL functional jobs on MySQL

Identical to #627, applied to `testcore12.yml` and `testcore13.yml`. The four
steps named `Functional MySQL 8.0 mysqli` / `... pdo_mysql` passed `-d mariadb`
and only duplicated the MariaDB steps above them; no workflow invoked `-d mysql`
at all. No version is pinned, `handleDbmsOptions` already defaults `-i` to `8.0`
for MySQL. The MariaDB steps are deliberately left alone — they claim 10.5 while
running the 10.4 default, a separate label defect.

### Own the sqlite tmpfs from the host user

Cherry-picked unchanged from `main` (`478465b`), it applied cleanly.

`${USERSET}` passes `--user ${HOST_UID}` without a group, so a docker container
runs as `uid=N gid=0(root)` and a `--tmpfs` comes up `root:root` with the mode of
its host mountpoint — 0755 at a CI umask of 0022, so the functional sqlite suite
fails with `unable to open database file`. The mount options move into
`TMPFS_MOUNT_OPTIONS` and are set per container binary; `${USERSET}` itself is
deliberately not changed.

### Render docs with own parameters

**This is the part `main` did not need.** Three defects sat on the one
`renderDocumentation` run line, so they are fixed together rather than by editing
it three times:

1. It hardcoded `-it` on top of `${CONTAINER_INTERACTIVE}`, which is already
   emptied when `CI=true`. Reproduced on the unmodified branch:

   ```
   $ CI=true Build/Scripts/runTests.sh -b docker -s renderDocumentation
   cannot attach stdin to a TTY-enabled container because stdin is not a terminal
   FAILURE
   ```

   Latent in the sense that no workflow on this branch invokes the suite — but it
   is a hard failure for anyone running it locally with `-b docker`, and it would
   bite the moment a documentation workflow is added.
2. It ran with `${CONTAINER_INTERACTIVE}` alone while `DOCUMENTATION_COMMON_PARAMS`
   was built for both container binaries and never used. That cost the container
   `--rm`, so every local render left a stopped container behind, and under docker
   it cost `${USERSET}` too, so rendered output was written back to the host owned
   by root.
3. It repeated the image literal that `IMAGE_DOCS` already holds, leaving that
   variable dead and the two free to drift apart.

`CI_PARAMS` is also assigned here (`CI_PARAMS="${CI_PARAMS:-}"`) — it was expanded
into the podman parameters and the mock server container but never assigned. It is
an escape hatch a caller can export, so the assignment is added rather than the
references removed. `--name` and `-w /project` match how `main` invokes the suite.

## Verification

Locally, under `umask 0022`, `CI=true`, `-b docker` — **24/24 green**:

* core 13 / PHP 8.2 and core 12 / PHP 8.1: `composerUpdate`, `cgl`, `phpstan`,
  `unit`, functional `sqlite`, `mysql -a mysqli`, `mysql -a pdo_mysql`,
  `mariadb -a mysqli`, plus `postgres` on core 13
* `renderDocumentation` under docker and podman — the suite that could not run on
  this branch at all before
* podman regression: functional sqlite on core 13, with `CI=true` and `CI` unset

One note on the last row: `renderDocumentation` with `CI` unset fails from a
non-interactive shell, because `CI` unset means `CONTAINER_INTERACTIVE="-it --init"`
is active by design and docker then wants a terminal. Re-run through a pseudo-TTY
(`script -qec`) it is `SUCCESS`. That is the intended mechanism, not a regression.

## Acceptance

* diff touches only `Build/Scripts/runTests.sh` and `.github/workflows/*`
* no workflow job, step, matrix entry or trigger added, removed or reordered
  (verified by comparing the parsed YAML structure against `5`)
* untouched as required: the `-b docker` flags and workflow header comment, the
  sqlite `mode=1777` option, the `waitFor` cap of 60 and its abort (block is
  byte-identical to `5`), and `CONTAINER_INTERACTIVE="-it --init"`

T5 of the issue does not apply to this branch — there is no `Documentation/Changelog/`
here. It follows as a separate pull request against `main`.
