### PR TITLE
[DOCS] DPL-197: Correct the 6.0 inline resolver changelog

### DIFF
--- a/Documentation/Changelog/6.0/Bugfix-InlineChildOfUntranslatableParent.rst
+++ b/Documentation/Changelog/6.0/Bugfix-InlineChildOfUntranslatableParent.rst
@@ -1,0 +1,74 @@
+..  _bugfix-inline-child-of-untranslatable-parent-1785481012:
+
+================================================
+Bugfix: Inline child of an untranslatable parent
+================================================
+
+
+Description
+===========
+
+Between 6.0.4 and 6.0.5 - and 5.1.7 to 5.1.8 on the 5.1 line - translating file
+metadata created nothing at all.
+
+`sys_file` declares `sys_file_metadata` as a connected mode inline child through
+a `foreign_field` pointer:
+
+..  code-block:: php
+
+    // typo3/cms-core Configuration/TCA/sys_file.php
+    'metadata' => [
+        'config' => [
+            'type' => 'inline',
+            'foreign_table' => 'sys_file_metadata',
+            'foreign_field' => 'file',
+        ],
+    ],
+
+but `sys_file` itself has neither `languageField` nor `transOrigPointerField` and
+can therefore never carry a localization, while `sys_file_metadata` has both.
+
+:php-short:`\WebVision\Deepltranslate\Core\Service\InlineRelationResolver` checked
+only that a candidate parent field points at the child table, carries no `MM` and
+has a non-empty `foreign_field`. It did not ask whether the parent table can be
+translated at all. Metadata records were therefore treated as inline children and
+their localization was handed over to
+:php:`\TYPO3\CMS\Core\DataHandling\DataHandler::inlineLocalizeSynchronize()` on the
+parent - which, without a parent localization, creates nothing. That behaviour is
+correct and documented, so the translated metadata record simply never appeared.
+
+Two fixes were needed, because the wrong answer was given at two levels:
+
+*   The per-record resolution now reports the new state
+    :php:`\WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState::ParentNotTranslatable`
+    for an inline child whose parent table is not translatable. It carries no
+    reference and is not a broken relation, so the hook falls through to the
+    regular localization and the child is localized on its own - the behaviour
+    from before the inline relation resolution was introduced.
+
+*   :php:`isPossibleInlineChildTable()` now counts only parents which can carry a
+    localization themselves. Callers use it to decide whether a record has to be
+    localized through its parent, and they have to decide that before the pointer
+    column of a newly created child record is written, so the per-record
+    resolution is not available to them. For `sys_file_metadata`, owned
+    exclusively by the untranslatable `sys_file`, the old answer made callers
+    skip the record entirely - which kept file metadata untranslated even with
+    the per-record resolution fixed.
+
+Both checks share one predicate, so they cannot drift apart.
+
+Impact
+======
+
+File metadata is translated again, as it was up to 6.0.3 and 5.1.6.
+
+More generally, an inline child in connected mode whose parent table is not
+translatable is localized on its own instead of being handed to a parent which
+can never carry a localization. The state is deliberately silent - it is a
+regular record configuration, not a broken relation, and is not reported to the
+editor.
+
+Detecting whether a table can be an inline child at all is otherwise unchanged.
+
+Released in 6.0.6 and 5.1.9. See issue `#618
+<https://github.com/web-vision/deepltranslate-core/issues/618>`__.

--- a/Documentation/Changelog/6.0/Feature-InlineRelationResolver.rst
+++ b/Documentation/Changelog/6.0/Feature-InlineRelationResolver.rst
@@ -32,18 +32,48 @@ Example
 
         public function isInlineChild(string $table, int $uid): bool
         {
-            return $this->inlineRelationResolver->resolveParentReference($table, $uid) !== null;
+            return $this->inlineRelationResolver
+                ->resolveParentReference($table, $uid)
+                ->isResolved();
         }
     }
 
-The returned :php-short:`\WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference`
-carries the child table and uid along with the resolved parent table, parent field,
-parent uid and the name of the `foreign_field` pointer column.
+:php:`resolveParentReference()` always returns an
+:php-short:`\WebVision\Deepltranslate\Core\Domain\Dto\InlineParentResolution`,
+never :php:`null`. It carries the outcome as an
+:php-short:`\WebVision\Deepltranslate\Core\Domain\Enum\InlineParentState` and, for
+a resolved relation, the
+:php-short:`\WebVision\Deepltranslate\Core\Domain\Dto\InlineParentReference` with
+the child table and uid, the resolved parent table, parent field and parent uid,
+and the name of the `foreign_field` pointer column.
 
-:php:`null` is returned if the record is not an inline child in connected mode, if
-the parent record does not exist or if the relation cannot be resolved
-unambiguously, for example when multiple parent tables point to the same child
-table without using `foreign_table_field`.
+The state lets a caller tell an ordinary standalone record apart from a broken
+relation configuration, which matters because only the latter is worth reporting
+to an editor:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   State
+        -   Meaning
+    *   -   `Resolved`
+        -   Inline child in connected mode, parent resolved unambiguously.
+            :php:`isResolved()` returns :php:`true` and a reference is carried.
+    *   -   `NotInlineChild`
+        -   Not an inline child in connected mode - the common case for any
+            standalone record. Localize normally, do not report.
+    *   -   `Ambiguous`
+        -   The record could be an inline child of more than one parent at the
+            same time, for example when multiple parent tables point to the same
+            child table without using `foreign_table_field`. Report it.
+    *   -   `ParentMissing`
+        -   The `foreign_field` points at a parent record which does not exist
+            (any more). Report it.
+    *   -   `ParentNotTranslatable`
+        -   Inline child in connected mode, but the parent table is not
+            translatable, most prominently `sys_file_metadata` owned by
+            `sys_file`. There can never be a parent localization to attach to, so
+            the child is localized on its own. Do not report.
 
 Resolving the parent requires the `foreign_field` pointer column of the child
 record to be written already, which is not the case during most of the
@@ -55,6 +85,13 @@ be used as inline child at all:
 
     $this->inlineRelationResolver->isPossibleInlineChildTable('sys_file_reference');
     // true - for example `tt_content.image` owns records of that table
+
+Only parents which can carry a localization themselves are counted here. A table
+owned exclusively by untranslatable parents - `sys_file_metadata`, owned by
+`sys_file` - is not reported as a possible inline child, because handing its
+localization to that parent could never produce anything. This matches the
+`ParentNotTranslatable` state of the per-record resolution; both share one
+predicate so they cannot drift apart.
 
 Impact
 ======

--- a/Documentation/Changelog/6.0/Important-InlineChildRecordsAreTranslatedThroughTheirParent.rst
+++ b/Documentation/Changelog/6.0/Important-InlineChildRecordsAreTranslatedThroughTheirParent.rst
@@ -37,3 +37,9 @@ record translation cannot be attached to anything. Nothing is created in that ca
 and a message is written to the system log, mirroring the behaviour of
 :php:`\TYPO3\CMS\Core\DataHandling\DataHandler::inlineLocalizeSynchronize()`.
 Translate the parent record first, which localizes its children along with it.
+
+This applies only to parents which can be translated at all. An inline child whose
+parent table carries no language configuration - `sys_file_metadata`, owned by the
+untranslatable `sys_file` - is not handed over and is localized on its own
+instead, because there could never be a parent localization to attach it to. See
+:ref:`bugfix-inline-child-of-untranslatable-parent-1785481012`.

--- a/Documentation/Changelog/6.0/Index.rst
+++ b/Documentation/Changelog/6.0/Index.rst
@@ -30,6 +30,16 @@ Features
 
     Feature-*
 
+Bugfix
+^^^^^^
+
+..  toctree::
+    :maxdepth: 1
+    :titlesonly:
+    :glob:
+
+    Bugfix-*
+
 Deprecation
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Third and last part of DPL-197, the documentation half. Companions: #627 (`main`
harness/workflows) and #628 (branch `5`). This one is `main` only — branch `5` has
no `Documentation/Changelog/` at all.

The issue asked for the `InlineRelationResolver` feature entry to be brought in
line with the two fixes released in 6.0.6 (#618). While doing that a second, older
drift turned up, so this pull request covers both.

### Fix the inline resolver changelog

`Feature-InlineRelationResolver.rst` documents an API that **has never shipped in
that shape**. The service was reworked after the entry was written — the result
became an object carrying a state enum — and that rework went out in **6.0.4**,
two releases before the ones the issue is about. The entry still promised a
nullable `InlineParentReference`:

```php
// documented — does not compile against any released 6.0.x
return $this->inlineRelationResolver->resolveParentReference($table, $uid) !== null;
```

`resolveParentReference()` returns an `InlineParentResolution` and never `null`.
The example uses `isResolved()` now, and the five `InlineParentState` cases are
documented in a table — the distinction is the point of the object, since an
ordinary standalone record and a broken relation configuration both mean "not
resolved" and only the latter should ever reach an editor.

`isPossibleInlineChildTable()` gained the note that only parents which can carry a
localization themselves are counted — the table-level half of the 6.0.6 fix.

### Add a bugfix entry for issue #618

New `Bugfix-InlineChildOfUntranslatableParent.rst` describing the regression
itself: between 6.0.4 and 6.0.5 translating file metadata created nothing at all,
because `sys_file` declares `sys_file_metadata` as a connected mode inline child
but cannot be translated itself, so the localization was handed to a parent which
can never carry one. Both halves of the fix are described.

Two supporting changes:

* `Index.rst` gained a **`Bugfix` section**. It globbed only `Breaking-*`,
  `Feature-*`, `Deprecation-*` and `Important-*`, so a bugfix entry would have
  rendered as a document outside of any toctree.
* `Important-InlineChildRecordsAreTranslatedThroughTheirParent.rst` now points at
  the new entry. On its own it reads as if an inline child is always handed over
  and skipped when the parent has no localization, which is no longer true for an
  untranslatable parent.

## Verification

* `runTests.sh -b docker -s renderDocumentation` — **SUCCESS**, 41 files rendered
* the new page renders **and is linked from the 6.0 index** under the new `Bugfix`
  heading — checked in the generated HTML, not just assumed from the toctree glob
* the `:ref:` from the important entry resolves to a real link with the entry title
* the five documented states were **diffed against the `InlineParentState` enum
  cases** and match exactly, so the entry cannot silently drift again
* RST adornment lengths checked against title lengths across all of
  `Documentation/Changelog/6.0/` — 0 mismatches

Note `renderDocumentation` runs with `--fail-on-error`, not `--fail-on-log`, so a
successful render alone would not have caught an orphan document. That is why the
link was verified in the rendered output.
