### PR TITLE
[BUGFIX] DPL-205: Restore the Resolved docblock

### DIFF
--- a/Classes/Domain/Enum/InlineParentState.php
+++ b/Classes/Domain/Enum/InlineParentState.php
@@ -31,9 +31,6 @@ enum InlineParentState
     case ParentMissing;
 
     /**
-     * The record is an inline child in connected mode and its parent was resolved unambiguously.
-     */
-    /**
      * The record is an inline child in connected mode, but the parent table itself is not
      * translatable - most prominently `sys_file_metadata`, which is owned by the
      * non-translatable `sys_file`. There can never be a parent localization to attach the
@@ -42,5 +39,8 @@ enum InlineParentState
      */
     case ParentNotTranslatable;
 
+    /**
+     * The record is an inline child in connected mode and its parent was resolved unambiguously.
+     */
     case Resolved;
 }


### PR DESCRIPTION
Resolves DPL-205.

Adding the `ParentNotTranslatable` case in `ec5f4e1` put its docblock **between**
the docblock of `Resolved` and `case Resolved;`. Two docblocks ended up stacked on
`ParentNotTranslatable` — the first of them describing a different case — and
`Resolved` was left with none.

```php
    /**
     * The record is an inline child in connected mode and its parent was resolved unambiguously.
     */
    /**
     * The record is an inline child in connected mode, but the parent table itself is not
     * translatable - ...
     */
    case ParentNotTranslatable;

    case Resolved;
```

`Resolved` is the case every caller branches on through `isResolved()`, so it was
the one state of the five an IDE could not explain — and hovering it showed the
`ParentNotTranslatable` text.

The docblock moves down to the case it belongs to. Comments only: no case, value
or order changes, and the enum keeps all five states.

Found while working DPL-197 and deliberately left out of it, because those pull
requests were restricted to `Build/Scripts/runTests.sh` and `.github/workflows/*`.
Shipped in 6.0.6, so the release notes need nothing — no behaviour changed.

## Verification

Structural, rather than by eye:

* no `*/` immediately followed by `/**` anywhere in the file — 0 occurrences
* all five cases parse with exactly one preceding docblock, none missing
* the diff changes only comment lines; no `case`/`enum` line is touched
* `php -l` clean

Suites, `umask 0022`, `CI=true`, `-b docker` — **10/10 green**: core 13 / PHP 8.2
and core 14 / PHP 8.4, each with `composerUpdate`, `cgl`, `phpstan`, `unit` and
functional sqlite.

One `composerUpdate` hit the known `class-alias-loader` transient
(`CaseSensitiveToken not found`) and poisoned `.Build` for the suites after it;
re-run after removing `.Build`, all green. Unrelated to a docblock change.

Branch `5` is affected identically and gets its own pull request.
