### PR TITLE
[TASK] DPL-206: Name the MariaDB steps 10.4

### DIFF
--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -77,10 +77,10 @@ jobs:
       - name: "Functional SQLite"
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
-      - name: "Functional MariaDB 10.5 mysqli"
+      - name: "Functional MariaDB 10.4 mysqli"
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
-      - name: "Functional MariaDB 10.5 pdo_mysql"
+      - name: "Functional MariaDB 10.4 pdo_mysql"
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"

--- a/.github/workflows/testcore14.yml
+++ b/.github/workflows/testcore14.yml
@@ -77,10 +77,10 @@ jobs:
       - name: "Functional SQLite"
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
-      - name: "Functional MariaDB 10.5 mysqli"
+      - name: "Functional MariaDB 10.4 mysqli"
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
 
-      - name: "Functional MariaDB 10.5 pdo_mysql"
+      - name: "Functional MariaDB 10.4 pdo_mysql"
         run: "Build/Scripts/runTests.sh -b docker -t 14 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
 
       - name: "Functional MySQL 8.0 mysqli"


### PR DESCRIPTION
Resolves DPL-206.

The four steps named `Functional MariaDB 10.5 …` pass no `-i`, so they run the
harness default — **10.4**. The label has been wrong since the steps were written.
The right database was always tested; only the version in the name was untrue.

This is the counterpart of the MySQL coverage gap fixed under DPL-197 (#627,
#628), and deliberately narrower: that one was a real gap — steps named MySQL ran
MariaDB — while here only the label is off.

## Why rename instead of raising the version

The issue offered raising `-i` to 10.5, or to a maintained LTS. The check that
settles it had not been done when the issue was written: what the supported TYPO3
versions actually require.

| Core | Minimum MariaDB | Minimum MySQL |
|---|---|---|
| 12.4 | 10.3.0 | 8.0.0 |
| 13.4 | **10.4.3** | 8.0.17 |
| 14 | **10.4.3** | 8.0.17 |

Source: `typo3/sysext/install/Classes/SystemEnvironment/DatabaseCheck/Platform/MySql.php`
on each core branch.

So 10.4 is exactly the lowest MariaDB TYPO3 v13 and v14 will install against, and
these steps are the guard against SQL that only works on a server newer than the
supported minimum. That is a regression class no other step in the matrix can
catch — SQLite, MySQL 8.0 and PostgreSQL 10 all pass while a below-minimum
MariaDB fails. Raising the version would have removed that coverage to make a
name true.

That MariaDB 10.4 is past its own upstream maintenance date is real but does not
bear on this: the version is pinned because TYPO3 still supports it, not because
MariaDB still ships fixes for it. It should be raised when TYPO3 raises its
minimum, not before.

Whether a **second**, current-LTS MariaDB step is also worth having is a separate
question — it means adding steps, which is outside the scope this and DPL-197
worked under, and it costs CI runtime. Not decided here.

## Change

Four `name:` lines across two files, `10.5` → `10.4`. No `run:` line is touched,
so no step changes what it executes.

## Verification

Scripted rather than by eye (`.sbuerk/tmp/verify-dpl206.sh`) — all checks pass:

* no `run:` line appears in the diff; the only changed lines are the four `name:` lines
* the parsed-YAML skeleton is byte-identical before/after — jobs, `needs`, `runs-on`,
  `strategy`, step order, every `uses:` and every `run:` command
* diffing the step-name lists yields exactly the two expected renames per file and
  nothing else
* no `MariaDB 10.5` label remains under `.github/` or `Build/`
* the MariaDB steps pass no `-i`, and the harness default is `10.4` — asserted
  against `runTests.sh`, so the label cannot drift from the default silently
* both workflows still parse

Note the first run of that script reported a false pass on the skeleton check: it
read the "after" side from `HEAD` while the change was still uncommitted, so it
compared the baseline against itself. It now reads the working tree and asserts
both that the baseline is non-empty and that a name difference exists at all.

Locally, `-t 13 -p 8.2 -s functional -d mariadb -a mysqli` was run to confirm the
container the label now names — the harness footer reports the DBMS and version it
actually used.

Branch `5` is affected identically (`testcore12.yml`, `testcore13.yml`) and gets
its own pull request.
