### PR TITLE
[BUGFIX] DPL-207: Wipe vendor tree on composerUpdate

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -554,7 +554,11 @@ case ${TEST_SUITE} in
     composerUpdate)
         # backup current composer.json
         cp -Rf composer.json composer.json.orig
-        rm -rf vendor composer.lock
+        # The vendor tree must go, not just the lock file: Composer boots plugins from
+        # it before resolving, so a leftover tree from another "-t" runs the previous
+        # core's "typo3/class-alias-loader" over the newly installed one. ".Build/.cache"
+        # is kept so the reinstall is served from the local Composer cache.
+        rm -rf .Build/vendor .Build/bin composer.lock
         ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-update-${CORE_VERSION}-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} composer require --dev "typo3/minimal":"^${CORE_VERSION}"
         SUITE_EXIT_CODE=$?
         # restore composer json


### PR DESCRIPTION
Fixes the `composerUpdate` suite so that switching `-t` between core versions
stops corrupting `.Build`. Resolves DPL-207.

## The defect

`Build/Scripts/runTests.sh` did `rm -rf vendor composer.lock`, but `composer.json`
sets `"vendor-dir": ".Build/vendor"` and this repository has no root `./vendor`.
The wipe was a **no-op on the package tree** — only the lock file was removed, and
Composer boots the plugins found in that stale tree before it resolves anything.

`typo3/class-alias-loader` is a `composer-plugin` whose version follows the core:

| Core | Constraint |
|---|---|
| 12.4 | `^1.1.4` |
| 13.4 | `^1.2` |
| 14 | `^2.0.1` |

`v2.0.1` deleted `src/IncludeFile/CaseSensitiveToken.php` and removed
`ClassAliasLoader::setCaseSensitiveClassLoading()`, so a `-t 13` -> `-t 14` switch
runs the v1 plugin in memory while v2 files land on disk underneath it.

## Reproduced before fixing, not assumed

From a tree with core v13.4.33 / class-alias-loader v1.2.2 installed, on the
unmodified script:

```
$ Build/Scripts/runTests.sh -b docker -t 14 -p 8.2 -s composerUpdate
  [Error]
  Class "TYPO3\ClassAliasLoader\IncludeFile\CaseSensitiveToken" not found
  at .Build/vendor/typo3/class-alias-loader/src/ClassAliasMapGenerator.php:139
FAILURE
```

The tree left behind is internally inconsistent — `installed.json` says `v2.0.1`,
`CaseSensitiveToken.php` is gone (replaced by `SuffixToken.php`), the on-disk
`ClassAliasLoader` no longer declares the method, yet the generated
`.Build/vendor/typo3/alias-loader-include.php:7` still calls it. Because that file
is registered in `.Build/vendor/composer/autoload_files.php` it executes on every
PHP bootstrap, so **an unrelated suite dies too**:

```
$ Build/Scripts/runTests.sh -b docker -t 14 -p 8.2 -s unit
PHP Fatal error:  Uncaught Error: Call to undefined method
TYPO3\ClassAliasLoader\ClassAliasLoader::setCaseSensitiveClassLoading()
in .Build/vendor/typo3/alias-loader-include.php:7
```

That is the "poisoned `.Build`" effect, and it is why the failure looked random
and unrelated to whatever was being worked on at the time.

## The fix

```
rm -rf .Build/vendor .Build/bin composer.lock
```

With no vendor tree at boot, Composer loads no third-party plugin at all; it
resolves, installs, and only then runs the freshly installed plugin for
`post-autoload-dump`. The mixed-version window cannot open.

`.Build/.cache` is deliberately kept, so the reinstall is served from the local
Composer cache rather than the network.

A conditional variant — stamping the last-installed core version and wiping only
on change — was rejected: it adds state, and an aborted run leaves the stamp
claiming a version that is only half installed.

## Verification

| Step | Result |
|---|---|
| `-t 14 -s composerUpdate` on the unfixed script | `FAILURE`, fatal above |
| `-t 14 -s unit` on the resulting tree | fatal at bootstrap |
| `-t 14 -s composerUpdate` **with the fix**, from that same poisoned tree | `SUCCESS` |
| `-t 13 -s composerUpdate` with the fix (reverse crossing) | `SUCCESS` |
| `-t 13 -s unit` afterwards | `OK (16 tests, 30 assertions)` |

The resulting tree is coherent: core `v13.4.33`, plugin `v1.2.2`, the on-disk
`ClassAliasLoader` declares `setCaseSensitiveClassLoading()`, and the generated
include calls it.

Note that the fix also **recovered the already-poisoned tree** on its own — no
manual `rm -rf .Build` was needed in between.

Precision about what was proven: the `-t 13` -> `-t 14` direction is demonstrated
to fail without the fix. The reverse direction is demonstrated to *succeed with*
the fix; it was not separately demonstrated to fail without it.

## Scope

CI is unaffected and cannot validate this change: every job checks out afresh,
no workflow caches `.Build`, and each workflow uses a single `-t`. The defect only
ever hit local core-version switches, so the proof above is local by necessity.

Behaviour on a fresh checkout is unchanged — the paths simply do not exist yet.

## Follow-ups, deliberately not in this PR

* Whether stale `.Build/Web/typo3/sysext` entries survive a `-t 14` -> `-t 13`
  downgrade. Plausible, unverified, separate concern.
* ~~The same line comes from the shared extension skeleton, so every harness with a
  `-t 14` selector is likely affected. Belongs to the portfolio sweep tracked
  under WVP-106.~~

**Correction (post-merge).** The claim above is wrong on both counts and is struck
rather than deleted, since it was published. The skeleton
(`sbuerk/templates/extension-skeleton-core-v13-and-v14`) does
`rm -rf .Build composer.lock composer.json.orig`, which always removes the vendor
tree; it also moved its Composer cache out to `.cache/composer` and carries an
explicit comment about `typo3/class-alias-loader` switching major versions.
`web-vision/extensions/a11y-by-default` documents the identical
`IncludeFile\...Token not found` failure. This repository **diverged** in
`8f555d8 [TASK] DPL-158: Cleaning up the household`, which replaced a
`composer-for-core-version.sh` call with a hand-written block containing
`rm -rf vendor composer.lock`.

A scan of every local harness found the broken line only under
`web-vision/deepl/dedicated/`:

| Repo | `-t` | State |
|---|---|---|
| `deepl-base` | 13/14 | **affected today**, identical line |
| `deepltranslate-auto-renew` | 12/13 | latent, both cores stay on v1.x |
| `deepltranslate-mass` | 12/13 | latent |
| `deepl-write` | 13/14 | fine (`rm -rf .Build/vendor`, only `.Build/bin` missing) |

Correct already: the skeleton and its demo, fgtclb `academic-extensions` /
`environment-state-manager` / `his-connector`, `a11y-by-default`,
`kanban-workspaces`. So this is a deepl-family divergence, not a portfolio-wide
skeleton defect, and it is not part of the WVP-106 MariaDB sweep.

