### PR TITLE
[BUGFIX] DPL-207: Wipe vendor tree on composerUpdate

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -552,7 +552,11 @@ case ${TEST_SUITE} in
     composerUpdate)
         # backup current composer.json
         cp -Rf composer.json composer.json.orig
-        rm -rf vendor composer.lock
+        # The vendor tree must go, not just the lock file: Composer boots plugins from
+        # it before resolving, so a leftover tree from another "-t" runs the previous
+        # core's "typo3/class-alias-loader" over the newly installed one. ".Build/.cache"
+        # is kept so the reinstall is served from the local Composer cache.
+        rm -rf .Build/vendor .Build/bin composer.lock
         ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-update-${CORE_VERSION}-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} composer require --dev "typo3/minimal":"^${CORE_VERSION}"
         SUITE_EXIT_CODE=$?
         # restore composer json


### PR DESCRIPTION
Branch `5` counterpart of #634. Resolves DPL-207 on this branch.

## The defect

`Build/Scripts/runTests.sh:555` did `rm -rf vendor composer.lock`, but
`composer.json` sets `"vendor-dir": ".Build/vendor"` and this repository has no
root `./vendor`. The wipe was a **no-op on the package tree** — only the lock file
was removed, and Composer boots the plugins found in that stale tree before it
resolves anything.

## This branch is affected, but latently

`typo3/class-alias-loader` is version-coupled to the core:

| Core | Constraint | On this branch |
|---|---|---|
| 12.4 | `^1.1.4` | supported |
| 13.4 | `^1.2` | supported |
| 14 | `^2.0.1` | not supported here |

`v2.0.1` deleted `IncludeFile/CaseSensitiveToken.php` and removed
`ClassAliasLoader::setCaseSensitiveClassLoading()`. Branch `5` never reaches that
version — and in practice both of its supported cores resolve to the *same* plugin
release, `v1.2.2`, since `^1.1.4` admits it. Verified in the built tree for `-t 12`:

```
core:   12.4.x-dev
plugin: v1.2.2
src/IncludeFile/: CaseSensitiveToken.php  PrependToken.php  TokenInterface.php
ClassAliasLoader::setCaseSensitiveClassLoading()  -> present
```

So switching `-t` here happens to stay compatible. **That is coincidence, not
design** — the incorrect path is identical to the one that breaks on `main`, and it
would bite the moment a supported core moves a plugin across an incompatible
release. Fixing only `main` would leave the harness depending on which plugin
versions the supported cores happen to agree on.

Reproduction of the hard failure and the full analysis are in #634; there is
nothing to reproduce on this branch, which is exactly the point.

## The fix

```
rm -rf .Build/vendor .Build/bin composer.lock
```

With no vendor tree at boot, Composer loads no third-party plugin at all; it
resolves, installs, and only then runs the freshly installed plugin for
`post-autoload-dump`. `.Build/.cache` is deliberately kept, so the reinstall comes
from the local Composer cache rather than the network.

## Verification (local, in a dedicated worktree)

| Step | Result |
|---|---|
| `-t 13 -p 8.2 -s composerUpdate` | `SUCCESS` |
| `-t 12 -p 8.1 -s composerUpdate` (switch) | `SUCCESS` |
| `-t 12 -p 8.1 -s unit` afterwards | `OK (14 tests, 71 assertions)` |

This is a no-regression proof, not a bug-fix proof — the defect is not reachable on
this branch, so the useful question here is only whether the corrected wipe still
produces a working tree for both supported cores. It does, in both directions.

## Scope

CI cannot validate this change either: every job checks out afresh, no workflow
caches `.Build`, and each workflow uses a single `-t`. Behaviour on a fresh
checkout is unchanged, since the removed paths do not exist yet.

## Follow-up

~~The line originates from the shared extension skeleton, so every harness with a
`-t 14` selector is likely affected for real. Tracked with the portfolio sweep
under WVP-106, not here.~~

**Correction (post-merge).** The claim above is wrong on both counts and is struck
rather than deleted, since it was published. The skeleton
(`sbuerk/templates/extension-skeleton-core-v13-and-v14`) does
`rm -rf .Build composer.lock composer.json.orig`, which always removes the vendor
tree; it also moved its Composer cache out to `.cache/composer` and carries an
explicit comment about `typo3/class-alias-loader` switching major versions.
`web-vision/extensions/a11y-by-default` documents the identical
`IncludeFile\...Token not found` failure. This repository **diverged** in
`8f555d8 [TASK] DPL-158: Cleaning up the household`, which replaced a
`composer-for-core-version.sh` call with a hand-written block containing
`rm -rf vendor composer.lock`.

A scan of every local harness found the broken line only under
`web-vision/deepl/dedicated/`:

| Repo | `-t` | State |
|---|---|---|
| `deepl-base` | 13/14 | **affected today**, identical line |
| `deepltranslate-auto-renew` | 12/13 | latent, both cores stay on v1.x |
| `deepltranslate-mass` | 12/13 | latent |
| `deepl-write` | 13/14 | fine (`rm -rf .Build/vendor`, only `.Build/bin` missing) |

Correct already: the skeleton and its demo, fgtclb `academic-extensions` /
`environment-state-manager` / `his-connector`, `a11y-by-default`,
`kanban-workspaces`. So this is a deepl-family divergence, not a portfolio-wide
skeleton defect, and it is not part of the WVP-106 MariaDB sweep.

