### PR TITLE
[TASK] DPL-215: Pin the database versions in CI

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -75,16 +75,16 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.4 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.4"
 
       - name: "Functional MariaDB 10.4 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql -i 10.4"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -i 8.0"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql -i 8.0"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 12 -p ${{ matrix.php-version }} -s functional -d postgres -i 10"

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -75,16 +75,16 @@ jobs:
         run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d sqlite"
 
       - name: "Functional MariaDB 10.4 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.4"
 
       - name: "Functional MariaDB 10.4 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql -i 10.4"
 
       - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -i 8.0"
 
       - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql -i 8.0"
 
       - name: "Functional PostgresSQL 10"
-        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres"
+        run: "Build/Scripts/runTests.sh -b docker -t 13 -p ${{ matrix.php-version }} -s functional -d postgres -i 10"


### PR DESCRIPTION
Closes the last inconsistency from the portfolio-wide database-label sweep.
Tracked as DPL-215.

The functional workflow steps named a database version but passed no `-i`, so each
ran whatever `handleDbmsOptions` defaults to. DPL-206 made the labels truthful by
**renaming** the MariaDB steps to the default they were already running — correct,
but it states the version in only one of the two places that decide it.

They now pass `-i` as well. **Versions are unchanged** — MariaDB 10.4, MySQL 8.0 and
PostgreSQL 10 are exactly what these jobs already ran — so CI coverage is identical
and only the intent becomes explicit. A later change to the harness defaults can no
longer move what these jobs test without the workflow saying so.

Sixteen repositories were converted to this shape on 2026-07-31; these two branches
were the remaining holdouts.

The SQLite steps deliberately get nothing — `handleDbmsOptions` rejects `-i` for
`-d sqlite`.

### Not part of this change

Whether **10.4** is still the right MariaDB to test. It is long past its
maintenance date, and `10.6`/`10.11` are long-term releases inside this branch's
allowed list — but changing it would change what is covered, which is a separate
decision and would breach the no-coverage-change constraint these follow-ups work
under. Pinning it explicitly at least makes the choice visible.

## Verification

Static; CI exercises the suites, and for this change CI is the stronger evidence
anyway since it actually starts the pinned containers.

* every workflow parses; diff touches `.github/workflows/*` only, no `runTests.sh`
* structural comparison against the base: all jobs, steps, matrix entries and
  triggers identical, only the intended `run` strings differ
* every labelled step re-derived from the parsed YAML: label version == `-i` value,
  and every `-i` is inside this branch's own `handleDbmsOptions` allowed list
* no `-d sqlite` step carries `-i`
* **coverage-unchanged check**: for each step, the effective version before (from
  the base's `-i` or its harness default) equals the effective version after
