### PR TITLE
[TASK] Mark this branch as end of life

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!CAUTION]
+> **This branch is end of life.**
+>
+> `4.x` is no longer maintained. It receives no bug fixes, no security fixes and
+> no further releases, and its CI pipeline is not kept working.
+>
+> Use a maintained branch instead: `main` (6.x) or `5` (5.x).
+>
+> Marked end of life on 2026-08-01.
+
 [![Latest Stable Version](https://poser.pugx.org/web-vision/wv_deepltranslate/v/stable.svg?style=for-the-badge)](https://packagist.org/packages/web-vision/wv_deepltranslate)
 [![License](https://poser.pugx.org/web-vision/wv_deepltranslate/license?style=for-the-badge)](https://packagist.org/packages/web-vision/wv_deepltranslate)
 [![TYPO3 11.5](https://img.shields.io/badge/TYPO3-11.5-green.svg?style=for-the-badge)](https://get.typo3.org/version/11)


### PR DESCRIPTION
Marks this branch end of life in the one place a reader looking at the branch will
see it.

The branch receives no bug fixes, no security fixes and no further releases, and its
CI pipeline is not kept working either. A `[!CAUTION]` note at the top of the README
states that and points at the maintained branches.

Nothing else changes — the diff is `README.md` only. No code, workflow or harness
change is part of this.

A read-only branch ruleset would express the same thing more forcefully, but is not
available on the DeepL add-on repositories: the rules API answers
`403 Upgrade to GitHub Pro or make this repository public to enable this feature`.
The README note is the mechanism that works consistently across all the affected
branches.
